### PR TITLE
Execute the RH service under a dedicated non-root user account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@ FROM openjdk:11-jre-slim
 
 ARG JAR_FILE=rhsvc*.jar
 RUN apt-get update
-RUN apt-get -yq install curl
 RUN apt-get -yq clean
+RUN groupadd -g 985 rhsvc && \
+    useradd -r -u 985 -g rhsvc rhsvc
+USER rhsvc
 COPY target/$JAR_FILE /opt/rhsvc.jar
 
-ENTRYPOINT [ "sh", "-c", "java", "$JAVA_OPTS", "-jar", "/opt/rhsvc.jar" ]
-
+ENTRYPOINT [ "java", "-jar", "/opt/rhsvc.jar" ]


### PR DESCRIPTION
# Motivation and Context
The principle of using least privilege should be followed when executing code within containers. Specifically, not running as root.

# What has changed
The Dockerfile has been changed:

* cURL should not be installed as it increases the attack surface of the container
* Create a dedicated non-root user account for executing the Java code
* The existing `ENTRYPOINT` command was poorly-formed:
  - The use of `sh -c` does not pass Unix signals to the Java process
  - When using the _exec_ form of `ENTRYPOINT` each argument should be its own array element
  - The `JAVA_OPTS` environment variable is Tomcat-specific and may be omitted. A separate PR linked below addresses passing options to the JVM via the standard `JAVA_TOOL_OPTIONS` environment variable

# How to test?
I tested this change by creating a differently tagged Docker image and deploying to my Kubernetes cluster. I verified that:

* The pod started successfully
* The Kubernetes readiness and liveness probes succeeded
* There were no errors in the container logs
* `exec`-ing into the container showed the Java process running as the expected non-root user account 

# Links
* https://docs.docker.com/engine/reference/builder/#entrypoint
* https://github.com/ONSdigital/census-rm-kubernetes/pull/14