### PR TITLE
Removing use of versioned xsd to prevent runtime downloads of mismatc…

### DIFF
--- a/src/main/resources/springintegration/broker.xml
+++ b/src/main/resources/springintegration/broker.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
-  http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit-1.6.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
 	<rabbit:connection-factory id="connectionFactory"
 	                           host="${rabbitmq.host}"

--- a/src/main/resources/springintegration/case-gateway-event-inbound.xml
+++ b/src/main/resources/springintegration/case-gateway-event-inbound.xml
@@ -5,7 +5,7 @@
        xmlns:int-amqp="http://www.springframework.org/schema/integration/amqp"
        xmlns:int-xml="http://www.springframework.org/schema/integration/xml"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-  http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+  http://www.springframework.org/schema/beans/spring-beans.xsd
   http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
   http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd
   http://www.springframework.org/schema/integration/xml http://www.springframework.org/schema/integration/xml/spring-integration-xml.xsd">

--- a/src/main/resources/springintegration/flows.xml
+++ b/src/main/resources/springintegration/flows.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:int="http://www.springframework.org/schema/integration"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-  http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+  http://www.springframework.org/schema/beans/spring-beans.xsd
   http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
     <int:annotation-config/>

--- a/src/main/resources/springintegration/main.xml
+++ b/src/main/resources/springintegration/main.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-	http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="flows.xml"/>
     <import resource="broker.xml"/>

--- a/src/main/resources/springintegration/respondent-service-event-outbound.xml
+++ b/src/main/resources/springintegration/respondent-service-event-outbound.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:rabbit="http://www.springframework.org/schema/rabbit"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-  http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+  http://www.springframework.org/schema/beans/spring-beans.xsd
   http://www.springframework.org/schema/rabbit
-  http://www.springframework.org/schema/rabbit/spring-rabbit-1.6.xsd">
+  http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
   
     <bean id="respondentEventJsonMessageConverter" class="org.springframework.amqp.support.converter.Jackson2JsonMessageConverter"/>
 

--- a/src/test/resources/caseEventReceiverImpl.xml
+++ b/src/test/resources/caseEventReceiverImpl.xml
@@ -4,7 +4,7 @@
        xmlns:int="http://www.springframework.org/schema/integration"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-  http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+  http://www.springframework.org/schema/beans/spring-beans.xsd
   http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
   http://www.springframework.org/schema/context
   http://www.springframework.org/schema/context/spring-context.xsd">


### PR DESCRIPTION
…hed versions

# Motivation and Context
This change has been done because it was discovered that using the versioned xsd's creates an external dependancy. 

On my machine the service startup time jumped from 5 seconds to 35 seconds, with a peak startup of 135 seconds. This was caused by Spring downloading the versioned xsd from the springframework website. This was confirmed by running 'curl http://www.springframework.org/schema/rabbit/spring-rabbit-1.6.xsd', which alone took about 15 seconds compared to 55ms later that afternoon.

There are several potential problems with this:
- Intermittent slow startup times impacts development.
- The external website might not be visible from test or production environments.
- Intermittently slow startup might lead the service to be terminated in a managed environment.
- Unknown and untested behaviour if springframework website is down.

There is no internet lookup if the specified version matches the available version. However, I found that both contact centre and RH were using incorrect version numbers. Note that it's not quite so clear cut as a jar aims for backwards compatability of key versions, which may prevent dynamic download. See [https://stackoverflow.com/questions/8609322/need-understanding-of-spring-handlers-and-spring-schemas](url)

# What has changed
Use of versioned xsd files has been replaced with the use of unversioned xsd references. Support for this seems to be a feature introduced in Spring 5 and as far as I could tell is generally regarded as best practice. 

Information about this is pretty sparse and I could not find a 100% definative statement about this. 

Plans for introduction for support of unversioned xsd references: https://github.com/spring-projects/spring-framework/issues/18077

Thread about this issue: https://stackoverflow.com/questions/1729307/spring-schemalocation-fails-when-there-is-no-internet-connection

# How to test?
Run all tests
