### PR TITLE
IT tests now mock receiver and its use of GCS

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/cloud/GCSDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/cloud/GCSDataStore.java
@@ -2,9 +2,6 @@ package uk.gov.ons.ctp.integration.rhsvc.cloud;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.auth.oauth2.ComputeEngineCredentials;
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -100,13 +97,15 @@ public class GCSDataStore implements CloudDataStore {
   }
 
   private void createBucket(String bucket, Storage storage) {
-    storage.create(BucketInfo.newBuilder(bucket)
-        // This is the cheapest option
-        // See here for possible values: http://g.co/cloud/storage/docs/storage-classes
-        .setStorageClass(StorageClass.COLDLINE)
-        // As John mentioned, I used Europe west 2 - location where data will be held
-        // Possible values: http://g.co/cloud/storage/docs/bucket-locations#location-mr
-        .setLocation(EUROPE_WEST_2).build());
+    storage.create(
+        BucketInfo.newBuilder(bucket)
+            // This is the cheapest option
+            // See here for possible values: http://g.co/cloud/storage/docs/storage-classes
+            .setStorageClass(StorageClass.COLDLINE)
+            // As John mentioned, I used Europe west 2 - location where data will be held
+            // Possible values: http://g.co/cloud/storage/docs/bucket-locations#location-mr
+            .setLocation(EUROPE_WEST_2)
+            .build());
   }
 
   private boolean getObjectFromCloud(String bucket, String key, Blob blob) {

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/CaseEventReceiverImplIT_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/CaseEventReceiverImplIT_Test.java
@@ -14,6 +14,7 @@ import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.ons.ctp.integration.rhsvc.domain.model.Address;
@@ -32,26 +33,24 @@ public class CaseEventReceiverImplIT_Test {
 
   @Autowired private CaseEventReceiverImpl receiver;
   @Autowired private SimpleMessageListenerContainer caseEventListenerContainer;
-  @Autowired private RespondentDataServiceImpl respondentDataServiceImpl;
+  @MockBean private RespondentDataServiceImpl respondentDataServiceImpl;
 
   /** Test the receiver flow */
   @Test
   public void caseEventFlowTest() throws Exception {
 
-    String bucket = "case_bucket";
-
     // Construct CaseEvent
     CaseEvent caseEvent = new CaseEvent();
     CasePayload casePayload = caseEvent.getPayload();
     CollectionCase collectionCase = casePayload.getCollectionCase();
-    Address address = collectionCase.getAddress();
-    Contact contact = collectionCase.getContact();
     collectionCase.setId("900000000");
     collectionCase.setCaseRef("10000000010");
     collectionCase.setSurvey("Census");
     collectionCase.setCollectionExerciseId("n66de4dc-3c3b-11e9-b210-d663bd873d93");
     collectionCase.setState("actionable");
     collectionCase.setActionableFrom("2011-08-12T20:17:46.384Z");
+
+    Address address = collectionCase.getAddress();
     address.setAddressLine1("1 main street");
     address.setAddressLine2("upper upperingham");
     address.setAddressLine3("");
@@ -64,11 +63,14 @@ public class CaseEventReceiverImplIT_Test {
     address.setArid("XXXXX");
     address.setAddressType("CE");
     address.setEstabType("XXX");
+
+    Contact contact = collectionCase.getContact();
     contact.setTitle("Ms");
     contact.setForename("jo");
     contact.setSurname("smith");
     contact.setEmail("me@example.com");
     contact.setTelNo("+447890000000");
+
     Header header = new Header();
     header.setType("CASE_UPDATED");
     header.setTransactionId("c45de4dc-3c3b-11e9-b210-d663bd873d93");
@@ -89,8 +91,5 @@ public class CaseEventReceiverImplIT_Test {
     ArgumentCaptor<CaseEvent> captur = ArgumentCaptor.forClass(CaseEvent.class);
     verify(receiver).acceptCaseEvent(captur.capture());
     assertTrue(captur.getValue().getPayload().equals(caseEvent.getPayload()));
-
-    // Tidy up by deleting the CaseEvent message from the case_bucket
-    respondentDataServiceImpl.deleteJsonFromCloud("900000000", bucket);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplIT_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplIT_Test.java
@@ -14,6 +14,7 @@ import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.ons.ctp.integration.rhsvc.domain.model.UAC;
@@ -30,7 +31,7 @@ public class UacEventReceiverImplIT_Test {
 
   @Autowired private UACEventReceiverImpl receiver;
   @Autowired private SimpleMessageListenerContainer uacEventListenerContainer;
-  @Autowired private RespondentDataServiceImpl respondentDataServiceImpl;
+  @MockBean private RespondentDataServiceImpl respondentDataServiceImpl;
 
   /** Test the receiver flow */
   @Test
@@ -69,8 +70,5 @@ public class UacEventReceiverImplIT_Test {
     ArgumentCaptor<UACEvent> captur = ArgumentCaptor.forClass(UACEvent.class);
     verify(receiver).acceptUACEvent(captur.capture());
     assertTrue(captur.getValue().getPayload().equals(uacEvent.getPayload()));
-
-    // Tidy up by deleting the CaseEvent message from the case_bucket
-    respondentDataServiceImpl.deleteJsonFromCloud("999999999", bucket);
   }
 }


### PR DESCRIPTION
IT tests for rabbit message receipt were not making any assertions after the message correctly delivered into the java receiver class, but it was then storing into GCS, the auth for which is problematic in travis. The IT tests now mock the receiver itself, avoiding the un-asserted use of GCS
