### PR TITLE
Cr 118 receive case events from rm - more changes after feedback from first pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ NB. The instructions will lead to a .json file being downloaded, which can be us
 NB. For more detailed information about setting up the Application Default Credential please see the following confluence article:
 https://collaborate2.ons.gov.uk/confluence/display/SDC/How+to+Set+Up+Google+Cloud+Platform+Locally
 
+Finally, create an environment variable to hold the name of your Google Cloud Platform project, using the export command at the terminal (in your census-rh-service repo):
+export GOOGLE_CLOUD_PROJECT="<name of your project>" e.g. export GOOGLE_CLOUD_PROJECT="census-rh-ellacook1"
+
 ## Running
 
 There are two ways of running this service

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/cloud/GCSDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/cloud/GCSDataStore.java
@@ -99,7 +99,6 @@ public class GCSDataStore implements CloudDataStore {
   private void createBucket(String bucket, Storage storage) {
     storage.create(
         BucketInfo.newBuilder(bucket)
-            // This is the cheapest option
             // See here for possible values: http://g.co/cloud/storage/docs/storage-classes
             .setStorageClass(StorageClass.REGIONAL)
             // As John mentioned, I used Europe west 2 - location where data will be held

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/cloud/GCSDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/cloud/GCSDataStore.java
@@ -101,7 +101,7 @@ public class GCSDataStore implements CloudDataStore {
         BucketInfo.newBuilder(bucket)
             // This is the cheapest option
             // See here for possible values: http://g.co/cloud/storage/docs/storage-classes
-            .setStorageClass(StorageClass.COLDLINE)
+            .setStorageClass(StorageClass.REGIONAL)
             // As John mentioned, I used Europe west 2 - location where data will be held
             // Possible values: http://g.co/cloud/storage/docs/bucket-locations#location-mr
             .setLocation(EUROPE_WEST_2)

--- a/src/main/resources/application-cloud.yaml
+++ b/src/main/resources/application-cloud.yaml
@@ -104,6 +104,5 @@ retries:
   backoff: 5000
 
 googleStorage:
-  class: StorageClass.COLDLINE
   caseBucketName: case
   uacBucketName: uac

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -14,6 +14,5 @@ schedules:
   distribution-schedule-delay-milli-seconds: 1000
 
 googleStorage:
-  class: StorageClass.COLDLINE
   caseBucketName: case
   uacBucketName: uac

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,6 +87,5 @@ retries:
   backoff: 5000
 
 googleStorage:
-  class: StorageClass.COLDLINE
   caseBucketName: case
   uacBucketName: uac

--- a/src/main/resources/springintegration/broker.xml
+++ b/src/main/resources/springintegration/broker.xml
@@ -51,36 +51,36 @@
 
 	<!-- Start of Exchanges -->
 
-	<rabbit:direct-exchange name="events">
+	<rabbit:topic-exchange name="events">
 		<rabbit:bindings>
-			<rabbit:binding queue="Case.Gateway" key="event.case.lifecycle" />
-			<rabbit:binding queue="UAC.Gateway" key="event.uac.updates" />
+			<rabbit:binding queue="Case.Gateway" pattern="event.case.lifecycle" />
+			<rabbit:binding queue="UAC.Gateway" pattern="event.uac.updates" />
 		</rabbit:bindings>
-	</rabbit:direct-exchange>
+	</rabbit:topic-exchange>
 
-	<rabbit:direct-exchange name="case-deadletter-exchange">
+	<rabbit:topic-exchange name="case-deadletter-exchange">
 		<rabbit:bindings>
-			<rabbit:binding queue="Case.GatewayDLQ" key="event.case.lifecycle" />
+			<rabbit:binding queue="Case.GatewayDLQ" pattern="event.case.lifecycle" />
 		</rabbit:bindings>
-	</rabbit:direct-exchange>
+	</rabbit:topic-exchange>
 
-	<rabbit:direct-exchange name="uac-deadletter-exchange">
+	<rabbit:topic-exchange name="uac-deadletter-exchange">
 		<rabbit:bindings>
-			<rabbit:binding queue="UAC.GatewayDLQ" key="event.uac.updates" />
+			<rabbit:binding queue="UAC.GatewayDLQ" pattern="event.uac.updates" />
 		</rabbit:bindings>
-	</rabbit:direct-exchange>
+	</rabbit:topic-exchange>
 
-	<rabbit:direct-exchange name="respondent-outbound-exchange">
+	<rabbit:topic-exchange name="respondent-outbound-exchange">
 		<rabbit:bindings>
-			<rabbit:binding queue="Respondent.Event" key="Respondent.Event.binding" />
+			<rabbit:binding queue="Respondent.Event" pattern="Respondent.Event.binding" />
 		</rabbit:bindings>
-	</rabbit:direct-exchange>
+	</rabbit:topic-exchange>
 
-	<rabbit:direct-exchange name="respondent-deadletter-exchange">
+	<rabbit:topic-exchange name="respondent-deadletter-exchange">
 		<rabbit:bindings>
-			<rabbit:binding queue="Respondent.EventDLQ" key="Respondent.Event.binding" />
+			<rabbit:binding queue="Respondent.EventDLQ" pattern="Respondent.Event.binding" />
 		</rabbit:bindings>
-	</rabbit:direct-exchange>
+	</rabbit:topic-exchange>
 
 	<!-- End of Exchanges -->
 

--- a/src/main/resources/springintegration/case-gateway-event-inbound.xml
+++ b/src/main/resources/springintegration/case-gateway-event-inbound.xml
@@ -44,6 +44,7 @@
     
     <bean id="rejectAndDontRequeueRecoverer" class="org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer"/>
 
+    <!-- The following template needs to be kept with the same settings as the uac retry Template in the uac-gateway-event-inbound xml -->
     <bean id="retryTemplate" class="org.springframework.retry.support.RetryTemplate">
         <property name="backOffPolicy">
             <bean class="org.springframework.retry.backoff.ExponentialBackOffPolicy">
@@ -60,6 +61,7 @@
             </bean>
         </property>
     </bean>
+
     <!-- End of section to deal with retries and DLQ after max attempts -->
 
 </beans>

--- a/src/main/resources/springintegration/uac-gateway-event-inbound.xml
+++ b/src/main/resources/springintegration/uac-gateway-event-inbound.xml
@@ -44,6 +44,7 @@
     
     <bean id="rejectUacAndDontRequeueRecoverer" class="org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer"/>
 
+    <!-- The following template needs to be kept with the same settings as the retry Template in the case-gateway-event-inbound xml -->
     <bean id="uacRetryTemplate" class="org.springframework.retry.support.RetryTemplate">
         <property name="backOffPolicy">
             <bean class="org.springframework.retry.backoff.ExponentialBackOffPolicy">
@@ -60,6 +61,7 @@
             </bean>
         </property>
     </bean>
+
     <!-- End of section to deal with retries and DLQ after max attempts -->
 
 </beans>


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Receives CaseCreated and CaseUpdated type messages and deserialises them into relevant Java objects (CaseEvent objects) and then stores them, as JSON, in a bucket, named [your-project-name]-case, within the Google Cloud Platform. Also receives UACUpdated type messages and deserialises them into UACEvent objects and then stores them, as JSON, in a bucket (named [your-project-name]-uac) within the Google Cloud Platform.

# What has changed
<!--- What code changes has been made -->
Since the original pull request was made on this branch (for the above required functionality) the only further changes in this request are as follows:
- the readme has been updated to include an instruction to create the environment variable named GOOGLE_CLOUD_PROJECT.
- the direct exchanges, defined in broker.xml, have been replaced with topic exchanges as per the guidance in the RM Event Model.
- the storage class of the buckets in GCP has been changed from COLDLINE to REGIONAL. This is because we expect to access the data more than once per year!
- some comments have been added regarding the retry templates (in the case-gateway-event-inbound.xml and uac-gateway-event-inbound.xml files) to ensure that these are kept in sink with each other.

<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
Use the readme file to firstly set up Google credentials locally. Then run Rabbitmq locally using the command 'docker-compose up -d'. Delete any ‘direct’ exchanges, which might have been created by running the census-rh-service previously, but don’t delete the default ones that begin with ‘amq’.

Now run the census-rh-service from the command line as follows:

mvn spring-boot:run

The RabbitMQ Management console should now show the following five exchanges listed as topic exchanges (not direct exchanges):

1. Case-deadletter-exchange
2. Events
3. Respondent-deadletter-exchange
4. Respondent-outbound-exchange
5. Uac-deadletter-exchange

Set up the events exchange, in the ‘Bindings’ section, so that it has the following two bindings defined:
1. To Case.Gateway, Routing key is event.case.lifecycle
2. To UAC.Gateway, Routing key is event.uac.updates

Create an environment variable to hold the name of your Google Cloud Platform project, using the export command at the terminal (in your census-rh-service repo): export GOOGLE_CLOUD_PROJECT = “your-project-name” e.g. census-rh-ellacook1 

Use the following JSON format to put a CaseUpdated type message on the events exchange, which should now be a topic exchange (and use event.case.lifecycle as the routing key when you publish the message). You can then run the code and should see the message appear in Google Cloud Platform within a bucket named your-project-name-case NB. To see the buckets you need to select Storage --> Browser (within GCP). The code will create the bucket if it does not already exist.

{
  "event" : {
    "type" : "CASE_UPDATED",
    "source" : "CASE_SERVICE",
    "channel" : "RM",
    "dateTime" : "2011-08-12T20:17:46.384Z",
    "transactionId" : "c45de4dc-3c3b-11e9-b210-d663bd873d93"
  },
  "payload" : {
    "collectionCase" : {
        "id":"bbd55984-0dbf-4499-bfa7-0aa4228700e9",
        "caseRef":"10000000010",
        "survey":"CENSUS",
        "collectionExerciseId":"n66de4dc-3c3b-11e9-b210-d663bd873d93",
        "address": {
		"addressLine1":"1 main street",
  		"addressLine2":"upper upperingham",
  		"addressLine3":"",
  		"townName":"upton",
  		"postcode":"UP103UP",
  		"region":"E",    
  		"latitude":"50.863849",
  		"longitude":"-1.229710",
  		"uprn":"XXXXXXXXXXXXX",
  		"arid":"XXXXX",
  		"addressType":"CE",
  		"estabType":"XXX"
	},
	"contact": {
	"title":"Ms",
  	"forename":"jo",
  	"surname":"smith",
  	"email":"me@example.com",
  	"telNo":"+447890000000"
	},
        "state":"ACTIONABLE",
        "actionableFrom":"2011-08-12T20:17:46.384Z"
}
  }
}

Then use the following JSON format to put a UACUpdated type message on the events exchange (and use event.uac.updates as the routing key when you publish the message). You can then run the code and should see the message appear in Google Cloud Platform within a bucket named your-project-name-uac. 

{
  "event" : {
    "type" : "UAC_UPDATED",
    "source" : "CASE_SERVICE",
    "channel" : "RM",
    "dateTime" : "2011-08-12T20:17:46.384Z",
    "transactionId" : "c45de4dc-3c3b-11e9-b210-d663bd873d93"
  },
  "payload" : {
    "uac" : {
        "uacHash":  "72C84BA99D77EE766E9468A0DE36433A44888E5DEC4AFB84F8019777800B7364",        
        "active" : true,
        "questionnaireId":"1110000009",
        "caseType":"H",
        "region":"E",
        "caseId":"bbd55984-0dbf-4499-bfa7-0aa4228700e9",
        "collectionExerciseId":"n66de4dc-3c3b-11e9-b210-d663bd873d93"
}
  }
}
