### PR TITLE
CR-198 Correct RH queue config

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,17 @@ rabbitmq:
   port: 35672
   virtualhost: /
 
+queueconfig:
+  event-exchange: case.outbound.exchange
+  dead-letter-exchange: events.deadletter.exchange
+  case-queue: case.rh.case
+  case-queue-DLQ: case.rh.case.dlq
+  case-routing-key: event.case.*
+  uac-queue: case.rh.uac
+  uac-queue-DLQ: case.rh.uac.dlq
+  uac-routing-key: event.uac.*
+  response-authentication-routing-key: event.response.authentication
+
 messaging:
   backoffInitial: 5000
   backoffMultiplier: 3

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,7 +63,7 @@ rabbitmq:
   virtualhost: /
 
 queueconfig:
-  event-exchange: case.outbound.exchange
+  event-exchange: events.exchange
   dead-letter-exchange: events.deadletter.exchange
   case-queue: case.rh.case
   case-queue-DLQ: case.rh.case.dlq

--- a/src/main/resources/springintegration/broker.xml
+++ b/src/main/resources/springintegration/broker.xml
@@ -23,7 +23,7 @@
 
 	<rabbit:queue name="Case.Gateway" durable="true">
 		<rabbit:queue-arguments value-type="java.lang.String">
-			<entry key="x-dead-letter-exchange" value="case-deadletter-exchange" />
+			<entry key="x-dead-letter-exchange" value="events-deadletter-exchange" />
 			<entry key="x-dead-letter-routing-key" value="event.case.lifecycle" />
 		</rabbit:queue-arguments>
 	</rabbit:queue>
@@ -32,55 +32,43 @@
 
 	<rabbit:queue name="UAC.Gateway" durable="true">
 		<rabbit:queue-arguments value-type="java.lang.String">
-			<entry key="x-dead-letter-exchange" value="uac-deadletter-exchange" />
+			<entry key="x-dead-letter-exchange" value="events-deadletter-exchange" />
 			<entry key="x-dead-letter-routing-key" value="event.uac.updates" />
 		</rabbit:queue-arguments>
 	</rabbit:queue>
 
 	<rabbit:queue name="UAC.GatewayDLQ" durable="true" />
 
-	<rabbit:queue name="Respondent.Event" durable="true">
-		<rabbit:queue-arguments value-type="java.lang.String">
-			<entry key="x-dead-letter-exchange" value="respondent-deadletter-exchange" />
-			<entry key="x-dead-letter-routing-key" value="Respondent.Event.binding" />
-		</rabbit:queue-arguments>
-	</rabbit:queue>
+    <rabbit:queue name="Events.AlternateQueue" durable="true" />
 
-	<rabbit:queue name="Respondent.EventDLQ" durable="true" />
 	<!-- End of Queues -->
 
 	<!-- Start of Exchanges -->
 
 	<rabbit:topic-exchange name="events">
+	    <rabbit:exchange-arguments>
+            <entry key="alternate-exchange" value="events-alternate-exchange" />
+	    </rabbit:exchange-arguments>
 		<rabbit:bindings>
 			<rabbit:binding queue="Case.Gateway" pattern="event.case.lifecycle" />
-			<rabbit:binding queue="UAC.Gateway" pattern="event.uac.updates" />
+		    <rabbit:binding queue="UAC.Gateway" pattern="event.uac.updates" />	
 		</rabbit:bindings>
 	</rabbit:topic-exchange>
 
-	<rabbit:topic-exchange name="case-deadletter-exchange">
+    <!-- Dead letter exchange for expired messages (where Time To Live set) or rejected messages -->
+	<rabbit:direct-exchange name="events-deadletter-exchange">
 		<rabbit:bindings>
-			<rabbit:binding queue="Case.GatewayDLQ" pattern="event.case.lifecycle" />
+			<rabbit:binding queue="Case.GatewayDLQ" key="event.case.lifecycle" />
+			<rabbit:binding queue="UAC.GatewayDLQ" key="event.uac.updates" />
 		</rabbit:bindings>
-	</rabbit:topic-exchange>
+	</rabbit:direct-exchange>
 
-	<rabbit:topic-exchange name="uac-deadletter-exchange">
+    <!-- Alternate exchange for messages that could not be routed by broker -->
+	<rabbit:fanout-exchange name="events-alternate-exchange">
 		<rabbit:bindings>
-			<rabbit:binding queue="UAC.GatewayDLQ" pattern="event.uac.updates" />
+			<rabbit:binding queue="Events.AlternateQueue" />
 		</rabbit:bindings>
-	</rabbit:topic-exchange>
-
-	<rabbit:topic-exchange name="respondent-outbound-exchange">
-		<rabbit:bindings>
-			<rabbit:binding queue="Respondent.Event" pattern="Respondent.Event.binding" />
-		</rabbit:bindings>
-	</rabbit:topic-exchange>
-
-	<rabbit:topic-exchange name="respondent-deadletter-exchange">
-		<rabbit:bindings>
-			<rabbit:binding queue="Respondent.EventDLQ" pattern="Respondent.Event.binding" />
-		</rabbit:bindings>
-	</rabbit:topic-exchange>
+	</rabbit:fanout-exchange>
 
 	<!-- End of Exchanges -->
 

--- a/src/main/resources/springintegration/broker.xml
+++ b/src/main/resources/springintegration/broker.xml
@@ -21,54 +21,42 @@
 
 	<!-- Start of Queues -->
 
-	<rabbit:queue name="Case.Gateway" durable="true">
+	<rabbit:queue name="${queueconfig.case-queue}" durable="true">
 		<rabbit:queue-arguments value-type="java.lang.String">
-			<entry key="x-dead-letter-exchange" value="events-deadletter-exchange" />
-			<entry key="x-dead-letter-routing-key" value="event.case.lifecycle" />
+			<entry key="x-dead-letter-exchange" value="${queueconfig.dead-letter-exchange}" />
+			<entry key="x-dead-letter-routing-key" value="${queueconfig.case-routing-key}" />
 		</rabbit:queue-arguments>
 	</rabbit:queue>
 
-	<rabbit:queue name="Case.GatewayDLQ" durable="true" />
+	<rabbit:queue name="${queueconfig.case-queue-DLQ}" durable="true" />
 
-	<rabbit:queue name="UAC.Gateway" durable="true">
+	<rabbit:queue name="${queueconfig.uac-queue}" durable="true">
 		<rabbit:queue-arguments value-type="java.lang.String">
-			<entry key="x-dead-letter-exchange" value="events-deadletter-exchange" />
-			<entry key="x-dead-letter-routing-key" value="event.uac.updates" />
+			<entry key="x-dead-letter-exchange" value="${queueconfig.dead-letter-exchange}" />
+			<entry key="x-dead-letter-routing-key" value="${queueconfig.uac-routing-key}" />
 		</rabbit:queue-arguments>
 	</rabbit:queue>
 
-	<rabbit:queue name="UAC.GatewayDLQ" durable="true" />
-
-    <rabbit:queue name="Events.AlternateQueue" durable="true" />
+	<rabbit:queue name="${queueconfig.uac-queue-DLQ}" durable="true" />
 
 	<!-- End of Queues -->
 
 	<!-- Start of Exchanges -->
 
-	<rabbit:topic-exchange name="events">
-	    <rabbit:exchange-arguments>
-            <entry key="alternate-exchange" value="events-alternate-exchange" />
-	    </rabbit:exchange-arguments>
+	<rabbit:topic-exchange name="${queueconfig.event-exchange}">
 		<rabbit:bindings>
-			<rabbit:binding queue="Case.Gateway" pattern="event.case.lifecycle" />
-		    <rabbit:binding queue="UAC.Gateway" pattern="event.uac.updates" />	
+			<rabbit:binding queue="${queueconfig.case-queue}" pattern="${queueconfig.case-routing-key}" />
+		    <rabbit:binding queue="${queueconfig.uac-queue}" pattern="${queueconfig.uac-routing-key}" />	
 		</rabbit:bindings>
 	</rabbit:topic-exchange>
 
     <!-- Dead letter exchange for expired messages (where Time To Live set) or rejected messages -->
-	<rabbit:direct-exchange name="events-deadletter-exchange">
+	<rabbit:direct-exchange name="${queueconfig.dead-letter-exchange}">
 		<rabbit:bindings>
-			<rabbit:binding queue="Case.GatewayDLQ" key="event.case.lifecycle" />
-			<rabbit:binding queue="UAC.GatewayDLQ" key="event.uac.updates" />
+			<rabbit:binding queue="${queueconfig.case-queue-DLQ}" key="${queueconfig.case-routing-key}" />
+			<rabbit:binding queue="${queueconfig.uac-queue-DLQ}" key="${queueconfig.uac-routing-key}" />
 		</rabbit:bindings>
 	</rabbit:direct-exchange>
-
-    <!-- Alternate exchange for messages that could not be routed by broker -->
-	<rabbit:fanout-exchange name="events-alternate-exchange">
-		<rabbit:bindings>
-			<rabbit:binding queue="Events.AlternateQueue" />
-		</rabbit:bindings>
-	</rabbit:fanout-exchange>
 
 	<!-- End of Exchanges -->
 

--- a/src/main/resources/springintegration/case-event-inbound.xml
+++ b/src/main/resources/springintegration/case-event-inbound.xml
@@ -12,7 +12,7 @@
     
     <bean id="caseEventListenerContainer" class="org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer">
         <property name="connectionFactory" ref="connectionFactory" />
-        <property name="queueNames" value="Case.Gateway" />
+        <property name="queueNames" value="${queueconfig.case-queue}" />
         <property name="adviceChain" ref="caseEventRetryAdvice" />
         <property name="concurrentConsumers" value="${messaging.consumingThreads}" />
         <property name="prefetchCount" value="${messaging.prefetchCount}" />

--- a/src/main/resources/springintegration/response-authentication-outbound.xml
+++ b/src/main/resources/springintegration/response-authentication-outbound.xml
@@ -9,6 +9,6 @@
   
     <bean id="surveyLaunchedJsonMessageConverter" class="org.springframework.amqp.support.converter.Jackson2JsonMessageConverter"/>
 
-    <rabbit:template id="surveyLaunchedRabbitTemplate" connection-factory="connectionFactory" exchange="events" routing-key="event.response.authentication"
+    <rabbit:template id="surveyLaunchedRabbitTemplate" connection-factory="connectionFactory" exchange="${queueconfig.event-exchange}" routing-key="${queueconfig.response-authentication-routing-key}"
                      message-converter="surveyLaunchedJsonMessageConverter" channel-transacted="true"/>
 </beans>

--- a/src/main/resources/springintegration/uac-event-inbound.xml
+++ b/src/main/resources/springintegration/uac-event-inbound.xml
@@ -12,7 +12,7 @@
     
     <bean id="uacEventListenerContainer" class="org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer">
         <property name="connectionFactory" ref="connectionFactory" />
-        <property name="queueNames" value="UAC.Gateway" />
+        <property name="queueNames" value="${queueconfig.uac-queue}" />
         <property name="adviceChain" ref="uacEventRetryAdvice" />
         <property name="concurrentConsumers" value="${messaging.consumingThreads}" />
         <property name="prefetchCount" value="${messaging.prefetchCount}" />


### PR DESCRIPTION
# Motivation and Context
Tidy exchanges, queues and bindings for RH service trying to avoid conflicts with RM services.

# What has changed
Broker.xml changed. New idea of alternate exchange introduced for messages which the broker cannot route.

# How to test?
Test as described in previous [Pull Request 14](https://github.com/ONSdigital/census-rh-service/pull/14). Using RabbitMQ management console by publishing with invalid routing you can test the message ends in the AlternateQueue. By corrupting the JSON message sent you can test the message ends in the relevant dead letter queue.
