### PR TITLE
Cr273 add fulfilments endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 # Respondent Home Data Service
 
 This repository contains the Respondent Data service. This microservice is a RESTful web service implemented using [Spring Boot](http://projects.spring.io/spring-boot/). It manages respondent data, where a Respondent Data object represents an expected response from the Respondent Data service, which provides all the data that is required by Respondent Home in order for it to verify the respondent's UAC code and connect them to the relevant EQ questionnaire.
+
 ## Set Up
 
 Do the following steps to set up the code to run locally:
@@ -174,7 +175,7 @@ If you know the case id which matches the stored UAC hash then you can supply it
  
 If the case id is not known for the loaded UAC data then you can manually force execution through by running in the debugger and set a breakpoint in UniqueAccessCodeServiceImpl::getSha256Hash(), and then manually replacing the calculated SHA256 value with the uacHash value of an already loaded UAC.
 
-To calculate the sha256 value for a case id:
+To calculate the sha256 value for a uac:
 
     $ echo -n "w4nwwpphjjptp7fn" | shasum -a 256
     8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4  -
@@ -220,4 +221,3 @@ Is switched off by default for clean deploy. Switch on with;
     
 ## Copyright
 Copyright (C) 2019 Crown Copyright (Office for National Statistics)
-

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>uk.gov.ons.ctp.integration.common</groupId>
+      <artifactId>product-reference</artifactId>
+      <version>0.0.10</version>
+    </dependency>
+
     <!-- ONS END -->
 
     <!-- third party libraries -->

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
@@ -59,7 +59,7 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
         fulfilmentsService.getFulfilments(caseType, region, deliveryChannel);
 
     log.info("Found {} fulfilment(s)", fulfilments.size());
-    
+
     return ResponseEntity.ok(fulfilments);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
@@ -1,0 +1,65 @@
+package uk.gov.ons.ctp.integration.rhsvc.endpoint;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.ons.ctp.common.endpoint.CTPEndpoint;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.integration.common.product.model.Product;
+import uk.gov.ons.ctp.integration.common.product.model.Product.CaseType;
+import uk.gov.ons.ctp.integration.common.product.model.Product.DeliveryChannel;
+import uk.gov.ons.ctp.integration.common.product.model.Product.Region;
+import uk.gov.ons.ctp.integration.rhsvc.service.FulfilmentsService;
+
+/** The REST controller for the RH Fulfilment end points */
+@RestController
+@RequestMapping(value = "/", produces = "application/json")
+public final class FulfilmentsEndpoint implements CTPEndpoint {
+  private static final Logger log = LoggerFactory.getLogger(FulfilmentsEndpoint.class);
+
+  private FulfilmentsService fulfilmentsService;
+
+  @Autowired
+  public FulfilmentsEndpoint(final FulfilmentsService fulfilmentsService) {
+    this.fulfilmentsService = fulfilmentsService;
+  }
+
+  /**
+   * The GET end point to retrieve fulfilment details, ie product codes for case type, region and
+   * delivery channel.
+   *
+   * <p>All request parameters are optional. If no parameters are specified then all products which
+   * are applicable to RH are returned.
+   *
+   * @param caseType is an optional parameter to specify the case type, eg, 'HI' or 'HH'
+   * @param region is an optional parameter to specify the region, eg, 'E' for England.
+   * @param deliveryChannel is an optional parameter to specify the delivery channel, eg, 'POST'.
+   * @return A list of matching products. The list will be empty if there are no matching products.
+   * @throws CTPException if something went wrong.
+   */
+  @RequestMapping(value = "/fulfilments", method = RequestMethod.GET)
+  public ResponseEntity<List<Product>> getFulfilments(
+      @RequestParam(required = false) CaseType caseType,
+      @RequestParam(required = false) Region region,
+      @RequestParam(required = false) DeliveryChannel deliveryChannel)
+      throws CTPException {
+
+    log.with("caseType", caseType)
+        .with("region", region)
+        .with("deliveryChannel", deliveryChannel)
+        .info("Entering GET getFulfilments");
+
+    List<Product> fulfilments =
+        fulfilmentsService.getFulfilments(caseType, region, deliveryChannel);
+
+    log.info("Found {} fulfilment(s)", fulfilments.size());
+    
+    return ResponseEntity.ok(fulfilments);
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/RespondentHomeEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/RespondentHomeEndpoint.java
@@ -6,7 +6,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.ons.ctp.common.endpoint.CTPEndpoint;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.integration.rhsvc.representation.SurveyLaunchedDTO;
 import uk.gov.ons.ctp.integration.rhsvc.service.RespondentHomeService;
@@ -17,7 +16,7 @@ import uk.gov.ons.ctp.integration.rhsvc.service.RespondentHomeService;
  */
 @RestController
 @RequestMapping(value = "/", produces = "application/json")
-public final class RespondentHomeEndpoint implements CTPEndpoint {
+public final class RespondentHomeEndpoint {
 
   private RespondentHomeService respondentHomeService;
 

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/FulfilmentsService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/FulfilmentsService.java
@@ -1,0 +1,14 @@
+package uk.gov.ons.ctp.integration.rhsvc.service;
+
+import java.util.List;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.integration.common.product.model.Product;
+import uk.gov.ons.ctp.integration.common.product.model.Product.CaseType;
+import uk.gov.ons.ctp.integration.common.product.model.Product.DeliveryChannel;
+import uk.gov.ons.ctp.integration.common.product.model.Product.Region;
+
+public interface FulfilmentsService {
+
+  List<Product> getFulfilments(CaseType caseType, Region region, DeliveryChannel deliveryChannel)
+      throws CTPException;
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImpl.java
@@ -1,0 +1,34 @@
+package uk.gov.ons.ctp.integration.rhsvc.service.impl;
+
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.integration.common.product.ProductReference;
+import uk.gov.ons.ctp.integration.common.product.model.Product;
+import uk.gov.ons.ctp.integration.common.product.model.Product.CaseType;
+import uk.gov.ons.ctp.integration.common.product.model.Product.DeliveryChannel;
+import uk.gov.ons.ctp.integration.common.product.model.Product.Region;
+import uk.gov.ons.ctp.integration.common.product.model.Product.RequestChannel;
+import uk.gov.ons.ctp.integration.rhsvc.service.FulfilmentsService;
+
+@Service
+public class FulfilmentsServiceImpl implements FulfilmentsService {
+  @Autowired ProductReference productReference;
+
+  @Override
+  public List<Product> getFulfilments(
+      CaseType caseType, Region region, DeliveryChannel deliveryChannel) throws CTPException {
+
+    Product example = new Product();
+    example.setRequestChannels(Arrays.asList(RequestChannel.RH));
+    example.setCaseType(caseType);
+    example.setRegions(region == null ? null : Arrays.asList(region));
+    example.setDeliveryChannel(deliveryChannel);
+
+    List<Product> products = productReference.searchProducts(example);
+
+    return products;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,8 +10,8 @@ info:
 # ie -Dlogging.level.org.springframework=DEBUG
 logging:
   level:
-    uk.gov.ons.ctp: DEBUG
-    org.springframework: DEBUG
+    uk.gov.ons.ctp: INFO
+    org.springframework: INFO
   profile: DEV
   useJson: false
 

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpointUnitTest.java
@@ -1,0 +1,83 @@
+package uk.gov.ons.ctp.integration.rhsvc.endpoint;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.ons.ctp.common.MvcHelper.getJson;
+import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.gov.ons.ctp.common.error.RestExceptionHandler;
+import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
+import uk.gov.ons.ctp.integration.common.product.model.Product;
+import uk.gov.ons.ctp.integration.rhsvc.service.FulfilmentsService;
+
+/**
+ * This class holds unit tests for the Fulfilments Endpoint to validate its handling of requests and
+ * their parameters.
+ */
+public final class FulfilmentsEndpointUnitTest {
+  @InjectMocks private FulfilmentsEndpoint fulfilmentsEndpoint;
+
+  @Mock FulfilmentsService fulfilmentsService;
+
+  private MockMvc mockMvc;
+
+  /**
+   * Set up of tests
+   *
+   * @throws Exception exception thrown
+   */
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    this.mockMvc =
+        MockMvcBuilders.standaloneSetup(fulfilmentsEndpoint)
+            .setHandlerExceptionResolvers(mockAdviceFor(RestExceptionHandler.class))
+            .setMessageConverters(new MappingJackson2HttpMessageConverter(new CustomObjectMapper()))
+            .build();
+  }
+
+  @Test
+  public void fulfilmentsReqestNoParameters() throws Exception {
+    List<Product> emptyList = new ArrayList<>();
+    Mockito.when(fulfilmentsService.getFulfilments(any(), any(), any())).thenReturn(emptyList);
+
+    mockMvc.perform(getJson("/fulfilments")).andExpect(status().isOk());
+  }
+
+  @Test
+  public void fulfilmentsReqestAllParameters() throws Exception {
+    List<Product> emptyList = new ArrayList<>();
+    Mockito.when(fulfilmentsService.getFulfilments(any(), any(), any())).thenReturn(emptyList);
+
+    mockMvc
+        .perform(getJson("/fulfilments?caseType=HI&region=E&deliveryChannel=SMS"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  public void fulfilmentsReqestWithInvalidCaseType() throws Exception {
+    mockMvc.perform(getJson("/fulfilments?caseType=X")).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void fulfilmentsReqestWithInvalidRegion() throws Exception {
+    mockMvc.perform(getJson("/fulfilments?region=X")).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void fulfilmentsReqestWithInvalidDeliveryChannel() throws Exception {
+    mockMvc.perform(getJson("/fulfilments?deliveryChannel=X")).andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
@@ -1,0 +1,67 @@
+package uk.gov.ons.ctp.integration.rhsvc.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import uk.gov.ons.ctp.integration.common.product.ProductReference;
+import uk.gov.ons.ctp.integration.common.product.model.Product;
+import uk.gov.ons.ctp.integration.common.product.model.Product.CaseType;
+import uk.gov.ons.ctp.integration.common.product.model.Product.DeliveryChannel;
+import uk.gov.ons.ctp.integration.common.product.model.Product.Region;
+import uk.gov.ons.ctp.integration.common.product.model.Product.RequestChannel;
+
+public class FulfilmentsServiceImplTest {
+
+  @Mock ProductReference productReference;
+
+  @InjectMocks FulfilmentsServiceImpl fulfilmentsService;
+
+  @Captor ArgumentCaptor<Product> exampleProductCaptor;
+
+  @Before
+  public void initMocks() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testFulfilmentsQuery() throws Exception {
+    // Mock the behaviour of the Product Reference
+    List<Product> mockedResults = new ArrayList<>();
+    Mockito.when(productReference.searchProducts(any())).thenReturn(mockedResults);
+    
+    // Invoke the method under test
+    List<Product> products = fulfilmentsService.getFulfilments(CaseType.HI, Region.E, DeliveryChannel.SMS);
+
+    // Get hold of the example product used in the search
+    Mockito.verify(productReference).searchProducts(exampleProductCaptor.capture());
+    Product capturedExampleProduct = exampleProductCaptor.getValue();
+    
+    // Verify the contents of the example product used in the search
+    assertEquals(1, capturedExampleProduct.getRequestChannels().size());
+    assertEquals(RequestChannel.RH, capturedExampleProduct.getRequestChannels().get(0));
+    assertEquals(CaseType.HI, capturedExampleProduct.getCaseType());
+    assertEquals(1, capturedExampleProduct.getRegions().size());
+    assertEquals(Region.E, capturedExampleProduct.getRegions().get(0));
+    assertEquals(DeliveryChannel.SMS, capturedExampleProduct.getDeliveryChannel());
+    assertNull(capturedExampleProduct.getFulfilmentCode());
+    assertNull(capturedExampleProduct.getInitialContactCode());
+    assertNull(capturedExampleProduct.getReminderContactCode());
+    assertNull(capturedExampleProduct.getFieldDistributionCode());
+    assertNull(capturedExampleProduct.getDescription());
+    assertNull(capturedExampleProduct.getLanguage());
+    assertNull(capturedExampleProduct.getHandler());
+    
+    // Verify that getFulfilments returns the value it got from the ProductReference search
+    assertEquals(mockedResults, products);
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ctp.integration.rhsvc.service.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
@@ -38,21 +39,26 @@ public class FulfilmentsServiceImplTest {
     // Mock the behaviour of the Product Reference
     List<Product> mockedResults = new ArrayList<>();
     Mockito.when(productReference.searchProducts(any())).thenReturn(mockedResults);
-    
+
     // Invoke the method under test
-    List<Product> products = fulfilmentsService.getFulfilments(CaseType.HI, Region.E, DeliveryChannel.SMS);
+    List<Product> products =
+        fulfilmentsService.getFulfilments(CaseType.HI, Region.E, DeliveryChannel.SMS);
 
     // Get hold of the example product used in the search
     Mockito.verify(productReference).searchProducts(exampleProductCaptor.capture());
     Product capturedExampleProduct = exampleProductCaptor.getValue();
-    
-    // Verify the contents of the example product used in the search
+
+    // Verify that the request to product reference was made as RH
     assertEquals(1, capturedExampleProduct.getRequestChannels().size());
     assertEquals(RequestChannel.RH, capturedExampleProduct.getRequestChannels().get(0));
+
+    // Verify the parameters are used in the product search
     assertEquals(CaseType.HI, capturedExampleProduct.getCaseType());
     assertEquals(1, capturedExampleProduct.getRegions().size());
     assertEquals(Region.E, capturedExampleProduct.getRegions().get(0));
     assertEquals(DeliveryChannel.SMS, capturedExampleProduct.getDeliveryChannel());
+
+    // Verify that nothing else was specified in the product search
     assertNull(capturedExampleProduct.getFulfilmentCode());
     assertNull(capturedExampleProduct.getInitialContactCode());
     assertNull(capturedExampleProduct.getReminderContactCode());
@@ -60,8 +66,8 @@ public class FulfilmentsServiceImplTest {
     assertNull(capturedExampleProduct.getDescription());
     assertNull(capturedExampleProduct.getLanguage());
     assertNull(capturedExampleProduct.getHandler());
-    
-    // Verify that getFulfilments returns the value it got from the ProductReference search
+
+    // Verify that getFulfilments() returns the value it got from the ProductReference search
     assertEquals(mockedResults, products);
   }
 }


### PR DESCRIPTION
# Motivation and Context
This change adds a fulfilments endpoint to RH. It basically does a search of ProductReference and returns the results. 

# What has changed
New endpoint added in FulfilmentsEndpoint.java and the code to call ProductReference is in FulfilmentsServiceImpl.java
Corresponding tests have been added.

# How to test?
Run all tests or manually send in a http request:
```
 $ http GET "http://localhost:8071/fulfilments?caseType=HI&region=E&deliveryChannel=SMS"
 $ http GET "http://localhost:8071/fulfilments?caseType=HI"
```

# Links
See CR: https://collaborate2.ons.gov.uk/jira/browse/CR-273
