### PR TITLE
Cr 470 adding rh feedback endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,21 @@ To manually test RH:
 
 1) **Queue setup**
  
-In the RabbitMQ console make sure that the following queues have been created and bound to the 'events' exchange:
+In the RabbitMQ console make sure that the following queues have been created and bound:
 
-      Routing key                    | Destination queue
-    ---------------------------------+--------------------------------
-      event.case.update              | case.rh.case
-      event.uac.update               | case.rh.uac
-      event.response.authentication  | event.response.authentication
+      Exchange  |  Routing key                    | Destination queue
+    ------------+---------------------------------+--------------------------------
+       events   |  event.case.update              | case.rh.case
+       events   |  event.uac.update               | case.rh.uac
+       events   |  event.response.authentication  | event.response.authentication
+       events   |  event.website.feedback         | website.feedback
+
+The following dead letter queues should be configured:
+
+      Exchange                      | Routing key        | Destination queue
+    --------------------------------+--------------------+---------------------
+       events.deadletter.exchange   | event.case.update  | case.rh.case.dlq
+       events.deadletter.exchange   | event.uac.update   | case.rh.uac.dlq
 
 2) **UAC Data**
 

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.14</version>
+      <version>0.0.15-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.15-SNAPSHOT</version>
+      <version>0.0.15</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FeedbackEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FeedbackEndpoint.java
@@ -1,0 +1,41 @@
+package uk.gov.ons.ctp.integration.rhsvc.endpoint;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.integration.rhsvc.representation.FeedbackDTO;
+import uk.gov.ons.ctp.integration.rhsvc.service.FeedbackService;
+
+/** The REST endpoint controller for UAC requests. */
+@RestController
+@RequestMapping(value = "/", produces = "application/json")
+public class FeedbackEndpoint {
+
+  private static final Logger log = LoggerFactory.getLogger(FeedbackEndpoint.class);
+
+  @Autowired private FeedbackService feedbackService;
+
+  /**
+   * the POST end-point to receive user feedback.
+   *
+   * @param feedbackDTO contains the feedback and data about the originating page.
+   * @return a response containing the id of the generated
+   * @throws CTPException something went wrong
+   */
+  @RequestMapping(value = "/feedback", method = RequestMethod.POST)
+  public ResponseEntity<String> submitFeedback(@RequestBody final FeedbackDTO feedbackDTO)
+      throws CTPException {
+
+    log.with("feedbackDTO", feedbackDTO).info("Entering POST submitFeedback");
+
+    String transactionId = feedbackService.processFeedback(feedbackDTO);
+
+    return ResponseEntity.ok(transactionId);
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FeedbackEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FeedbackEndpoint.java
@@ -13,7 +13,7 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.integration.rhsvc.representation.FeedbackDTO;
 import uk.gov.ons.ctp.integration.rhsvc.service.FeedbackService;
 
-/** The REST endpoint controller for UAC requests. */
+/** The REST endpoint controller for recording website feedback. */
 @RestController
 @RequestMapping(value = "/", produces = "application/json")
 public class FeedbackEndpoint {
@@ -25,9 +25,9 @@ public class FeedbackEndpoint {
   /**
    * the POST end-point to receive user feedback.
    *
-   * @param feedbackDTO contains the feedback and data about the originating page.
-   * @return a response containing the id of the generated
-   * @throws CTPException something went wrong
+   * @param feedbackDTO contains the feedback and data about an originating page.
+   * @return a response containing the id of the generated feedback event.
+   * @throws CTPException something went wrong.
    */
   @RequestMapping(value = "/feedback", method = RequestMethod.POST)
   public ResponseEntity<String> submitFeedback(@Valid @RequestBody final FeedbackDTO feedbackDTO)

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FeedbackEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FeedbackEndpoint.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.integration.rhsvc.endpoint;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,7 +30,7 @@ public class FeedbackEndpoint {
    * @throws CTPException something went wrong
    */
   @RequestMapping(value = "/feedback", method = RequestMethod.POST)
-  public ResponseEntity<String> submitFeedback(@RequestBody final FeedbackDTO feedbackDTO)
+  public ResponseEntity<String> submitFeedback(@Valid @RequestBody final FeedbackDTO feedbackDTO)
       throws CTPException {
 
     log.with("feedbackDTO", feedbackDTO).info("Entering POST submitFeedback");

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/FeedbackDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/FeedbackDTO.java
@@ -1,0 +1,22 @@
+package uk.gov.ons.ctp.integration.rhsvc.representation;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.Data;
+
+/** Representation of end-user feedback data */
+@Data
+public class FeedbackDTO {
+
+  @NotNull
+  @Size(max = 1000)
+  private String pageUrl;
+
+  @NotNull
+  @Size(max = 1000)
+  private String pageTitle;
+
+  @NotNull
+  @Size(max = 10000)
+  private String feedbackText;
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/FeedbackDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/FeedbackDTO.java
@@ -3,10 +3,13 @@ package uk.gov.ons.ctp.integration.rhsvc.representation;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.Data;
+import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
 
 /** Representation of end-user feedback data */
 @Data
 public class FeedbackDTO {
+
+  @NotNull private Channel channel;
 
   @NotNull
   @Size(max = 1000)

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/FeedbackService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/FeedbackService.java
@@ -1,0 +1,17 @@
+package uk.gov.ons.ctp.integration.rhsvc.service;
+
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.integration.rhsvc.representation.FeedbackDTO;
+
+/** Service responsible for recording end-user feedback */
+public interface FeedbackService {
+
+  /**
+   * Forwards end-user feedback to a queue for subsequent processing.
+   *
+   * @param feedbackDTO contains the end-users feedback.
+   * @return a String containing the transaction id used when the feedback was sent to Rabbit.
+   * @throws CTPException something went wrong.
+   */
+  String processFeedback(FeedbackDTO feedbackDTO) throws CTPException;
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FeedbackServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FeedbackServiceImpl.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.EventPublisher;
-import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
 import uk.gov.ons.ctp.common.event.EventPublisher.Source;
 import uk.gov.ons.ctp.common.event.model.Feedback;
@@ -24,7 +23,7 @@ public class FeedbackServiceImpl implements FeedbackService {
 
     String transactionId =
         eventPublisher.sendEvent(
-            EventType.FEEDBACK, Source.RESPONDENT_HOME, Channel.RM, feedbackResponse);
+            EventType.FEEDBACK, Source.RESPONDENT_HOME, feedbackDTO.getChannel(), feedbackResponse);
 
     return transactionId;
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FeedbackServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FeedbackServiceImpl.java
@@ -11,6 +11,7 @@ import uk.gov.ons.ctp.integration.rhsvc.representation.FeedbackDTO;
 import uk.gov.ons.ctp.integration.rhsvc.service.FeedbackService;
 
 @Service
+/** Service responsible for recording end-user feedback */
 public class FeedbackServiceImpl implements FeedbackService {
   @Autowired private EventPublisher eventPublisher;
 

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FeedbackServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FeedbackServiceImpl.java
@@ -1,0 +1,31 @@
+package uk.gov.ons.ctp.integration.rhsvc.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.event.EventPublisher;
+import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
+import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
+import uk.gov.ons.ctp.common.event.EventPublisher.Source;
+import uk.gov.ons.ctp.common.event.model.Feedback;
+import uk.gov.ons.ctp.integration.rhsvc.representation.FeedbackDTO;
+import uk.gov.ons.ctp.integration.rhsvc.service.FeedbackService;
+
+@Service
+public class FeedbackServiceImpl implements FeedbackService {
+  @Autowired private EventPublisher eventPublisher;
+
+  @Override
+  public String processFeedback(FeedbackDTO feedbackDTO) throws CTPException {
+    Feedback feedbackResponse = new Feedback();
+    feedbackResponse.setPageUrl(feedbackDTO.getPageUrl());
+    feedbackResponse.setPageTitle(feedbackDTO.getPageTitle());
+    feedbackResponse.setFeedbackText(feedbackDTO.getFeedbackText());
+
+    String transactionId =
+        eventPublisher.sendEvent(
+            EventType.FEEDBACK, Source.RESPONDENT_HOME, Channel.RM, feedbackResponse);
+
+    return transactionId;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -113,6 +113,8 @@ queueconfig:
   uac-queue-DLQ: case.rh.uac.dlq
   uac-routing-key: event.uac.update
   response-authentication-routing-key: event.response.authentication
+  feedback-queue: website.feedback
+  feedback-routing-key: event.website.feedback
 
 messaging:
   backoffInitial: 5000

--- a/src/main/resources/springintegration/broker.xml
+++ b/src/main/resources/springintegration/broker.xml
@@ -39,6 +39,8 @@
 
 	<rabbit:queue name="${queueconfig.uac-queue-DLQ}" durable="true" />
 
+	<rabbit:queue name="${queueconfig.feedback-queue}" durable="true" />
+
 	<!-- End of Queues -->
 
 	<!-- Start of Exchanges -->
@@ -47,6 +49,7 @@
 		<rabbit:bindings>
 			<rabbit:binding queue="${queueconfig.case-queue}" pattern="${queueconfig.case-routing-key}" />
 		    <rabbit:binding queue="${queueconfig.uac-queue}" pattern="${queueconfig.uac-routing-key}" />	
+		    <rabbit:binding queue="${queueconfig.feedback-queue}" pattern="${queueconfig.feedback-routing-key}" />
 		</rabbit:bindings>
 	</rabbit:topic-exchange>
 

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FeedbackEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FeedbackEndpointUnitTest.java
@@ -1,0 +1,113 @@
+package uk.gov.ons.ctp.integration.rhsvc.endpoint;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.ons.ctp.common.MvcHelper.postJson;
+import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.gov.ons.ctp.common.FixtureHelper;
+import uk.gov.ons.ctp.common.error.RestExceptionHandler;
+import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
+import uk.gov.ons.ctp.integration.rhsvc.representation.FeedbackDTO;
+import uk.gov.ons.ctp.integration.rhsvc.service.FeedbackService;
+
+/**
+ * This class holds unit tests for the Feedback Endpoint to validate its handling of requests and
+ * their parameters.
+ */
+public final class FeedbackEndpointUnitTest {
+  @InjectMocks private FeedbackEndpoint feedbackEndpoint;
+
+  @Mock FeedbackService feedbackService;
+
+  private MockMvc mockMvc;
+
+  private ObjectMapper mapper = new ObjectMapper();
+
+  private FeedbackDTO feedbackDTO;
+
+  /**
+   * Set up of tests
+   *
+   * @throws Exception exception thrown
+   */
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    this.mockMvc =
+        MockMvcBuilders.standaloneSetup(feedbackEndpoint)
+            .setHandlerExceptionResolvers(mockAdviceFor(RestExceptionHandler.class))
+            .setMessageConverters(new MappingJackson2HttpMessageConverter(new CustomObjectMapper()))
+            .build();
+
+    this.feedbackDTO = FixtureHelper.loadClassFixtures(FeedbackDTO[].class).get(0);
+  }
+
+  @Test
+  public void feedbackSubmittal_valid() throws Exception {
+    String feedbackAsJson = mapper.writeValueAsString(feedbackDTO);
+    mockMvc.perform(postJson("/feedback", feedbackAsJson)).andExpect(status().isOk());
+  }
+
+  @Test
+  public void feedbackSubmittal_nullChannel() throws Exception {
+    feedbackDTO.setChannel(null);
+    String feedbackAsJson = mapper.writeValueAsString(feedbackDTO);
+    mockMvc.perform(postJson("/feedback", feedbackAsJson)).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void feedbackSubmittal_pageUrlIsNull() throws Exception {
+    feedbackDTO.setPageUrl(null);
+    String feedbackAsJson = mapper.writeValueAsString(feedbackDTO);
+    mockMvc.perform(postJson("/feedback", feedbackAsJson)).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void feedbackSubmittal_pageUrlTooLong() throws Exception {
+    feedbackDTO.setPageUrl(createLongString(4000));
+    String feedbackAsJson = mapper.writeValueAsString(feedbackDTO);
+    mockMvc.perform(postJson("/feedback", feedbackAsJson)).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void feedbackSubmittal_pageTitleIsNull() throws Exception {
+    feedbackDTO.setPageTitle(null);
+    String feedbackAsJson = mapper.writeValueAsString(feedbackDTO);
+    mockMvc.perform(postJson("/feedback", feedbackAsJson)).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void feedbackSubmittal_pageTitleTooLong() throws Exception {
+    feedbackDTO.setPageTitle(createLongString(4000));
+    String feedbackAsJson = mapper.writeValueAsString(feedbackDTO);
+    mockMvc.perform(postJson("/feedback", feedbackAsJson)).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void feedbackSubmittal_feedbackIsNull() throws Exception {
+    feedbackDTO.setFeedbackText(null);
+    String feedbackAsJson = mapper.writeValueAsString(feedbackDTO);
+    mockMvc.perform(postJson("/feedback", feedbackAsJson)).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void feedbackSubmittal_FeedbackTooLong() throws Exception {
+    feedbackDTO.setFeedbackText(createLongString(15000));
+    String feedbackAsJson = mapper.writeValueAsString(feedbackDTO);
+    mockMvc.perform(postJson("/feedback", feedbackAsJson)).andExpect(status().isBadRequest());
+  }
+
+  private String createLongString(int len) {
+    return "x".repeat(len);
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FeedbackServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FeedbackServiceImplTest.java
@@ -1,0 +1,58 @@
+package uk.gov.ons.ctp.integration.rhsvc.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import uk.gov.ons.ctp.common.event.EventPublisher;
+import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
+import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
+import uk.gov.ons.ctp.common.event.EventPublisher.Source;
+import uk.gov.ons.ctp.common.event.model.Feedback;
+import uk.gov.ons.ctp.integration.rhsvc.representation.FeedbackDTO;
+
+public class FeedbackServiceImplTest {
+
+  @Mock EventPublisher publisher;
+
+  @InjectMocks FeedbackServiceImpl feedbackService;
+
+  @Captor ArgumentCaptor<Feedback> sendEventCaptor;
+
+  @Before
+  public void initMocks() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testFeedbackEventGenerated() throws Exception {
+    // Give a feedback DTO to the service layer
+    FeedbackDTO feedbackDTO = new FeedbackDTO();
+    feedbackDTO.setChannel(Channel.EQ);
+    feedbackDTO.setPageUrl("http://100.2.20.99/start");
+    feedbackDTO.setPageTitle("Random Title");
+    feedbackDTO.setFeedbackText("Bla bla");
+    feedbackService.processFeedback(feedbackDTO);
+
+    // Intercept call to EventPublisher, and capture supplied payload
+    Mockito.verify(publisher)
+        .sendEvent(
+            eq(EventType.FEEDBACK),
+            eq(Source.RESPONDENT_HOME),
+            eq(feedbackDTO.getChannel()),
+            sendEventCaptor.capture());
+    Feedback feedback = sendEventCaptor.getValue();
+
+    // Verify contents of payload object given to EventPublisher
+    assertEquals(feedbackDTO.getPageUrl(), feedback.getPageUrl());
+    assertEquals(feedbackDTO.getPageTitle(), feedback.getPageTitle());
+    assertEquals(feedbackDTO.getFeedbackText(), feedback.getFeedbackText());
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
@@ -105,7 +105,6 @@ public class UniqueAccessCodeServiceImplTest {
   @Test
   public void getUniqueAccessCodeDataUACFoundWithCaseID() throws Exception {
     UAC uacTest = uac.get(0);
-    CollectionCase caseTest = collectionCase.get(0);
     when(dataRepo.readUAC(UAC_HASH)).thenReturn(Optional.of(uacTest));
     when(dataRepo.readCollectionCase(CASE_ID)).thenReturn(Optional.empty());
 

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/endpoint/FeedbackEndpointUnitTest.FeedbackDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/endpoint/FeedbackEndpointUnitTest.FeedbackDTO.json
@@ -1,0 +1,6 @@
+{
+  "channel": "RH",
+  "pageUrl": "/1.2.3.4/pageX",
+  "pageTitle": "Dummy page",
+  "feedbackText": "Made up feedback text"
+}


### PR DESCRIPTION
# Motivation and Context
This change adds an endpoint for recording end user feedback about the website. It writes the content of the feedback to a queue for subsequent processing.

# What has changed

- Addition of Feedback endpoint.
- Added Feedback service.
- Added unit tests to execute the new code.

# How to test?
Run the unit tests.

To manually test run RH locally and then copy+paste the following:
```
cat > /tmp/feedbackDTO.json << EOF
{
  "channel": "EQ",
  "pageUrl": "/1.2.3.4/pageX",
  "pageTitle": "Dummy page",
  "feedbackText": "Made up feedback text"
}
EOF

http POST "http://localhost:8071/feedback" @/tmp/feedbackDTO.json
```

# Links
See: https://collaborate2.ons.gov.uk/jira/browse/CR-470