### PR TITLE
Cr 500 rabbit failures on restart

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,6 +115,7 @@ queueconfig:
   response-authentication-routing-key: event.response.authentication
 
 messaging:
+  mismatchedQueuesFatal: true
   backoffInitial: 5000
   backoffMultiplier: 3
   backoffMax: 45000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,13 +120,8 @@ messaging:
   backoffMultiplier: 3
   backoffMax: 45000
   consumingThreads: 1
-  pubMaxAttempts: 3
   conMaxAttempts: 3
   prefetchCount: 1
-  txSize: 1
-
-report-settings:
-  cron-expression: "0 * * * * *"
 
 swagger-settings:
   swagger-ui-active: true
@@ -134,10 +129,6 @@ swagger-settings:
   title: RespondentHomeService
   description: API for ${project.artifactId}
   version: ${project.version}
-
-retries:
-  maxAttempts: 3
-  backoff: 5000
 
 googleStorage:
   caseSchemaName: case

--- a/src/main/resources/springintegration/case-event-inbound.xml
+++ b/src/main/resources/springintegration/case-event-inbound.xml
@@ -12,6 +12,7 @@
     
     <bean id="caseEventListenerContainer" class="org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer">
         <property name="connectionFactory" ref="connectionFactory" />
+        <property name="mismatchedQueuesFatal" value="${messaging.mismatchedQueuesFatal}" />
         <property name="queueNames" value="${queueconfig.case-queue}" />
         <property name="adviceChain" ref="caseEventRetryAdvice" />
         <property name="concurrentConsumers" value="${messaging.consumingThreads}" />

--- a/src/main/resources/springintegration/uac-event-inbound.xml
+++ b/src/main/resources/springintegration/uac-event-inbound.xml
@@ -12,6 +12,7 @@
     
     <bean id="uacEventListenerContainer" class="org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer">
         <property name="connectionFactory" ref="connectionFactory" />
+        <property name="mismatchedQueuesFatal" value="${messaging.mismatchedQueuesFatal}" />
         <property name="queueNames" value="${queueconfig.uac-queue}" />
         <property name="adviceChain" ref="uacEventRetryAdvice" />
         <property name="concurrentConsumers" value="${messaging.consumingThreads}" />

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/EventReceiverConfiguration.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/EventReceiverConfiguration.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.rabbitmq.client.Channel;
 import org.mockito.Mockito;
+import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.context.annotation.Bean;
@@ -42,5 +43,10 @@ public class EventReceiverConfiguration {
   @Bean
   public UACEventReceiverImpl uacEventReceiver() {
     return Mockito.spy(new UACEventReceiverImpl());
+  }
+
+  @Bean
+  public AmqpAdmin amqpAdmin() {
+    return mock(AmqpAdmin.class);
   }
 }


### PR DESCRIPTION
# Motivation and Context
This change stops RH from starting if a mismatch is detected between the actual and the desired queue configuration.
Such a change prevents the problems described in CR-500, in which RH initially runs but will become progressively more zombied with each Rabbit stop/start cycle.

# What has changed
- Config updated.
- Unused config deleted.
- Unit tests fixed to get them running again.

# Links
See: https://collaborate2.ons.gov.uk/jira/browse/CR-500#