### PR TITLE
CR-494 UAC request from RHUI now hashed

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,7 @@ Submit the case by sending the following to the 'events' exchange with the routi
 
 If you know the case id which matches the stored UAC hash then you can supply it in the UACS get request:
   
-       $ curl -s -H "Content-Type: application/json" "http://localhost:8071/uacs/w4nwwpphjjptp7fn"
- 
-If the case id is not known for the loaded UAC data then you can manually force execution through by running in the debugger and set a breakpoint in UniqueAccessCodeServiceImpl::getSha256Hash(), and then manually replacing the calculated SHA256 value with the uacHash value of an already loaded UAC.
+       $ curl -s -H "Content-Type: application/json" "http://localhost:8071/uacs/8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4"
 
 To calculate the sha256 value for a uac:
 
@@ -267,7 +265,7 @@ This example uses a case uuid of: f868fcfc-7280-40ea-ab01-b173ac245da3
     http --auth generator:hitmeup  get "http://localhost:8171/firestore/wait?collection=case&key=f868fcfc-7280-40ea-ab01-b173ac245da3&timeout=1s"
 
     # Make the UAC authenticated request
-    http --auth serco_cks:temporary get "http://localhost:8071/uacs/aaaabbbbccccdddd"
+    http --auth serco_cks:temporary get "http://localhost:8071/uacs/147eb9dcde0e090429c01dbf634fd9b69a7f141f005c387a9c00498908499dde"
 
     # Grab respondent authenticated event
     http --auth generator:hitmeup GET "http://localhost:8171/rabbit/get/event.response.authentication?timeout=500ms"

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/UniqueAccessCodeEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/UniqueAccessCodeEndpoint.java
@@ -24,16 +24,16 @@ public class UniqueAccessCodeEndpoint {
   /**
    * the GET end-point to get RH details for a claim
    *
-   * @param uac the UAC
+   * @param uacHash the hashed UAC
    * @return the claim details
    * @throws CTPException something went wrong
    */
-  @RequestMapping(value = "/{uac}", method = RequestMethod.GET)
+  @RequestMapping(value = "/{uacHash}", method = RequestMethod.GET)
   public ResponseEntity<UniqueAccessCodeDTO> getUACClaimContext(
-      @PathVariable("uac") final String uac) throws CTPException {
+      @PathVariable("uacHash") final String uacHash) throws CTPException {
 
     log.info("Entering GET getUACClaimContext");
-    UniqueAccessCodeDTO uacDTO = uacService.getAndAuthenticateUAC(uac);
+    UniqueAccessCodeDTO uacDTO = uacService.getAndAuthenticateUAC(uacHash);
 
     return ResponseEntity.ok(uacDTO);
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/UniqueAccessCodeDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/UniqueAccessCodeDTO.java
@@ -1,7 +1,5 @@
 package uk.gov.ons.ctp.integration.rhsvc.representation;
 
-import com.godaddy.logging.LoggingScope;
-import com.godaddy.logging.Scope;
 import java.util.UUID;
 import lombok.Data;
 
@@ -16,9 +14,7 @@ public class UniqueAccessCodeDTO {
     NOT_FOUND
   }
 
-  @LoggingScope(scope = Scope.SKIP)
-  private String uac;
-
+  private String uacHash;
   private boolean active;
   private CaseStatus caseStatus;
   private String questionnaireId;

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/UniqueAccessCodeService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/UniqueAccessCodeService.java
@@ -7,11 +7,11 @@ import uk.gov.ons.ctp.integration.rhsvc.representation.UniqueAccessCodeDTO;
 public interface UniqueAccessCodeService {
 
   /**
-   * Retrieve the data for a UAC
+   * Retrieve the data for a hashed UAC
    *
-   * @param uac unique access code for which to retrieve data
+   * @param uacHash hashed unique access code for which to retrieve data
    * @return UniqueAccessCodeDTO representing data for UAC
    * @throws CTPException something wernt wrong
    */
-  UniqueAccessCodeDTO getAndAuthenticateUAC(String uac) throws CTPException;
+  UniqueAccessCodeDTO getAndAuthenticateUAC(String uacHash) throws CTPException;
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/UniqueAccessCodeEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/UniqueAccessCodeEndpointTest.java
@@ -25,7 +25,8 @@ import uk.gov.ons.ctp.integration.rhsvc.service.UniqueAccessCodeService;
 /** Unit Tests on endpoint for UAC resources */
 public class UniqueAccessCodeEndpointTest {
 
-  private static final String UAC = "w4nwwpphjjpt";
+  private static final String UAC_HASH =
+      "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4";
   private static final String CASE_ID = "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4";
   private static final String POSTCODE = "UP103UP";
   private static final String ERROR_CODE = "RESOURCE_NOT_FOUND";
@@ -53,13 +54,13 @@ public class UniqueAccessCodeEndpointTest {
   /** Test returns valid JSON for valid UAC */
   @Test
   public void getUACClaimContextUACFound() throws Exception {
-    when(uacService.getAndAuthenticateUAC(UAC)).thenReturn(uacDTO.get(0));
+    when(uacService.getAndAuthenticateUAC(UAC_HASH)).thenReturn(uacDTO.get(0));
 
     mockMvc
-        .perform(get(String.format("/uacs/%s", UAC)))
+        .perform(get(String.format("/uacs/%s", UAC_HASH)))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json;charset=UTF-8"))
-        .andExpect(jsonPath("$.uac", is(UAC)))
+        .andExpect(jsonPath("$.uacHash", is(UAC_HASH)))
         .andExpect(jsonPath("$.caseId", is(CASE_ID)))
         .andExpect(jsonPath("$.address.postcode", is(POSTCODE)));
   }
@@ -67,11 +68,11 @@ public class UniqueAccessCodeEndpointTest {
   /** Test returns resource not found for invalid UAC */
   @Test
   public void getUACClaimContextUACNotFound() throws Exception {
-    when(uacService.getAndAuthenticateUAC(UAC))
+    when(uacService.getAndAuthenticateUAC(UAC_HASH))
         .thenThrow(new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, ERROR_MESSAGE));
 
     mockMvc
-        .perform(get("/uacs/{uac}", UAC))
+        .perform(get("/uacs/{uac}", UAC_HASH))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.error.code", is(ERROR_CODE)))
         .andExpect(jsonPath("$.error.message", is(ERROR_MESSAGE)));

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
@@ -33,9 +33,8 @@ import uk.gov.ons.ctp.integration.rhsvc.representation.UniqueAccessCodeDTO.CaseS
 /** Unit tests of the Unique Access Code Service */
 public class UniqueAccessCodeServiceImplTest {
 
-  private static final String UAC = "w4nwwpphjjpt";
   private static final String UAC_HASH =
-      "97a2e785f8cffc8f40b5e8fc626933bb8aedf3df82672299bf7aeafe68c99c93";
+      "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4";
   private static final String CASE_ID = "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4";
 
   @InjectMocks private UniqueAccessCodeServiceImpl uacSvc;
@@ -67,7 +66,7 @@ public class UniqueAccessCodeServiceImplTest {
     when(dataRepo.readUAC(UAC_HASH)).thenReturn(Optional.of(uacTest));
     when(dataRepo.readCollectionCase(CASE_ID)).thenReturn(Optional.of(caseTest));
 
-    UniqueAccessCodeDTO uacDTO = uacSvc.getAndAuthenticateUAC(UAC);
+    UniqueAccessCodeDTO uacDTO = uacSvc.getAndAuthenticateUAC(UAC_HASH);
 
     verify(dataRepo, times(1)).readUAC(UAC_HASH);
     verify(dataRepo, times(1)).readCollectionCase(CASE_ID);
@@ -78,7 +77,7 @@ public class UniqueAccessCodeServiceImplTest {
             eq(Channel.RH),
             payloadCapture.capture());
 
-    assertEquals(UAC, uacDTO.getUac());
+    assertEquals(UAC_HASH, uacDTO.getUacHash());
     assertEquals(Boolean.valueOf(uacTest.getActive()), uacDTO.isActive());
     assertEquals(CaseStatus.OK, uacDTO.getCaseStatus());
     assertEquals(UUID.fromString(uacTest.getCaseId()), uacDTO.getCaseId());
@@ -109,13 +108,13 @@ public class UniqueAccessCodeServiceImplTest {
     when(dataRepo.readUAC(UAC_HASH)).thenReturn(Optional.of(uacTest));
     when(dataRepo.readCollectionCase(CASE_ID)).thenReturn(Optional.empty());
 
-    UniqueAccessCodeDTO uacDTO = uacSvc.getAndAuthenticateUAC(UAC);
+    UniqueAccessCodeDTO uacDTO = uacSvc.getAndAuthenticateUAC(UAC_HASH);
 
     verify(dataRepo, times(1)).readUAC(UAC_HASH);
     verify(dataRepo, times(1)).readCollectionCase(CASE_ID);
     verify(eventPublisher, times(0)).sendEvent(any(), any(), any(), any());
 
-    assertEquals(UAC, uacDTO.getUac());
+    assertEquals(UAC_HASH, uacDTO.getUacHash());
     assertEquals(Boolean.valueOf(uacTest.getActive()), uacDTO.isActive());
     assertEquals(CaseStatus.NOT_FOUND, uacDTO.getCaseStatus());
     assertEquals(UUID.fromString(uacTest.getCaseId()), uacDTO.getCaseId());
@@ -135,13 +134,13 @@ public class UniqueAccessCodeServiceImplTest {
     uacTest.setCaseId(null);
     when(dataRepo.readUAC(UAC_HASH)).thenReturn(Optional.of(uacTest));
 
-    UniqueAccessCodeDTO uacDTO = uacSvc.getAndAuthenticateUAC(UAC);
+    UniqueAccessCodeDTO uacDTO = uacSvc.getAndAuthenticateUAC(UAC_HASH);
 
     verify(dataRepo, times(1)).readUAC(UAC_HASH);
     verify(dataRepo, times(0)).readCollectionCase(CASE_ID);
     verify(eventPublisher, times(0)).sendEvent(any(), any(), any(), any());
 
-    assertEquals(UAC, uacDTO.getUac());
+    assertEquals(UAC_HASH, uacDTO.getUacHash());
     assertEquals(Boolean.valueOf(uacTest.getActive()), uacDTO.isActive());
     assertEquals(CaseStatus.UNKNOWN, uacDTO.getCaseStatus());
     assertEquals(null, uacDTO.getCaseId());
@@ -163,7 +162,7 @@ public class UniqueAccessCodeServiceImplTest {
 
     boolean exceptionThrown = false;
     try {
-      uacSvc.getAndAuthenticateUAC(UAC);
+      uacSvc.getAndAuthenticateUAC(UAC_HASH);
     } catch (CTPException e) {
       exceptionThrown = true;
     }

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/endpoint/UniqueAccessCodeEndpointTest.UniqueAccessCodeDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/endpoint/UniqueAccessCodeEndpointTest.UniqueAccessCodeDTO.json
@@ -1,5 +1,5 @@
 {
-	"uac": "w4nwwpphjjpt",
+	"uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
 	"active": true,
 	"questionnaireId": 1110000009,
 	"caseType": "HH",

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.UAC.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.UAC.json
@@ -1,5 +1,5 @@
 {
-	"uacHash": "97a2e785f8cffc8f40b5e8fc626933bb8aedf3df82672299bf7aeafe68c99c93",
+	"uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
 	"active": true,
 	"questionnaireId": "1110000009",
 	"caseType": "HH",


### PR DESCRIPTION
# Motivation and Context
The endpoint receiving requests for UAC details has been changed to use a hash of the UAC as a path parameter rather than the UAC itself. The functionality to hash a UAC has been removed as this is now done by the client.

# What has changed
UniqueAccessCodeEndpoint and underlying service changed to use hash of UAC as path parameter in request. 

# How to test?
Unit tests altered to reflect change. Running the application as normal will work as before with a valid UAC.

Note, must be released with [related RH UI PR](https://github.com/ONSdigital/census-rh-ui/pull/55)