### PR TITLE
Cr 763

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,3 +9,4 @@ coverage:
 ignore:
 - "src/tests/"
 - "migration/"
+- "src/main/**/*DTO.java"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,4 +9,3 @@ coverage:
 ignore:
 - "src/tests/"
 - "migration/"
-- "src/main/**/*DTO.java"

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>product-reference</artifactId>
-      <version>0.0.21</version>
+      <version>1.0.2-SNAPSHOT</version>
     </dependency>
 
     <!-- ONS END -->

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.integration.rhsvc.endpoint;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,7 +64,7 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
         .with("requestParam.individual", individual)
         .with("requestParam.productGroup", productGroup)
         .info("Entering GET getFulfilments");
-    List<CaseType> caseTypes = caseType == null ? Collections.emptyList() : caseType.toList();
+    List<CaseType> caseTypes = caseType == null ? Collections.emptyList() : Arrays.asList(caseType);
     List<ProductDTO> fulfilments =
         fulfilmentsService.getFulfilments(
             caseTypes, region, deliveryChannel, productGroup, individual);

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.integration.rhsvc.endpoint;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,8 +58,7 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
         .with("requestParam.deliveryChannel", deliveryChannel)
         .with("requestParam.individual", individual)
         .info("Entering GET getFulfilments");
-    List<CaseType> caseTypes = caseType == null ? Collections.emptyList() : caseType.toList();
-    individual = (individual == null ? true : individual);
+    List<CaseType> caseTypes = caseType == null ? Collections.emptyList() : Arrays.asList(caseType);
     List<Product> fulfilments =
         fulfilmentsService.getFulfilments(caseTypes, region, deliveryChannel, individual);
 

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
@@ -16,6 +16,7 @@ import uk.gov.ons.ctp.integration.common.product.model.Product;
 import uk.gov.ons.ctp.integration.common.product.model.Product.CaseType;
 import uk.gov.ons.ctp.integration.common.product.model.Product.DeliveryChannel;
 import uk.gov.ons.ctp.integration.common.product.model.Product.Region;
+import uk.gov.ons.ctp.integration.rhsvc.representation.ProductDTO;
 import uk.gov.ons.ctp.integration.rhsvc.service.FulfilmentsService;
 
 /** The REST controller for the RH Fulfilment end points */
@@ -48,7 +49,7 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
    * @throws CTPException if something went wrong.
    */
   @RequestMapping(value = "/fulfilments", method = RequestMethod.GET)
-  public ResponseEntity<List<Product>> getFulfilments(
+  public ResponseEntity<List<ProductDTO>> getFulfilments(
       @RequestParam(required = false) CaseType caseType,
       @RequestParam(required = false) Region region,
       @RequestParam(required = false) DeliveryChannel deliveryChannel,
@@ -63,7 +64,7 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
         .with("requestParam.productGroup", productGroup)
         .info("Entering GET getFulfilments");
     List<CaseType> caseTypes = caseType == null ? Collections.emptyList() : caseType.toList();
-    List<Product> fulfilments =
+    List<ProductDTO> fulfilments =
         fulfilmentsService.getFulfilments(
             caseTypes, region, deliveryChannel, productGroup, individual);
 

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
@@ -2,7 +2,6 @@ package uk.gov.ons.ctp.integration.rhsvc.endpoint;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,7 +40,10 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
    *
    * @param caseType is an optional parameter to specify the case type, eg, 'HI' or 'HH'
    * @param region is an optional parameter to specify the region, eg, 'E' for England.
-   * @param deliveryChannel is an optional parameter to specify the delivery channel, eg, 'POST'.
+   * @param deliveryChannel is an optional parameter to specify the delivery channel, eg, 'POST'
+   * @param individual is an optional parameter to specify whether this is a query about an
+   *     individual or a household
+   * @param productGroup is an optional parameter to specify the product group, eg 'UAC'
    * @return A list of matching products. The list will be empty if there are no matching products.
    * @throws CTPException if something went wrong.
    */
@@ -50,17 +52,20 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
       @RequestParam(required = false) CaseType caseType,
       @RequestParam(required = false) Region region,
       @RequestParam(required = false) DeliveryChannel deliveryChannel,
-      @RequestParam(required = false) Boolean individual)
+      @RequestParam(required = false) Boolean individual,
+      @RequestParam(required = false) Product.ProductGroup productGroup)
       throws CTPException {
 
     log.with("requestParam.caseType", caseType)
         .with("requestParam.region", region)
         .with("requestParam.deliveryChannel", deliveryChannel)
         .with("requestParam.individual", individual)
+        .with("requestParam.productGroup", productGroup)
         .info("Entering GET getFulfilments");
-    List<CaseType> caseTypes = caseType == null ? Collections.emptyList() : Arrays.asList(caseType);
+    List<CaseType> caseTypes = caseType == null ? Collections.emptyList() : caseType.toList();
     List<Product> fulfilments =
-        fulfilmentsService.getFulfilments(caseTypes, region, deliveryChannel, individual);
+        fulfilmentsService.getFulfilments(
+            caseTypes, region, deliveryChannel, productGroup, individual);
 
     log.with("size", fulfilments.size()).info("Found fulfilment(s)");
 

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.integration.rhsvc.endpoint;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -47,16 +48,19 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
   public ResponseEntity<List<Product>> getFulfilments(
       @RequestParam(required = false) CaseType caseType,
       @RequestParam(required = false) Region region,
-      @RequestParam(required = false) DeliveryChannel deliveryChannel)
+      @RequestParam(required = false) DeliveryChannel deliveryChannel,
+      @RequestParam(required = false) Boolean individual)
       throws CTPException {
 
     log.with("requestParam.caseType", caseType)
         .with("requestParam.region", region)
         .with("requestParam.deliveryChannel", deliveryChannel)
+        .with("requestParam.individual", individual)
         .info("Entering GET getFulfilments");
-
+    List<CaseType> caseTypes = caseType == null ? Collections.emptyList() : caseType.toList();
+    individual = (individual == null ? true : individual);
     List<Product> fulfilments =
-        fulfilmentsService.getFulfilments(caseType, region, deliveryChannel);
+        fulfilmentsService.getFulfilments(caseTypes, region, deliveryChannel, individual);
 
     log.with("size", fulfilments.size()).info("Found fulfilment(s)");
 

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/ProductDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/ProductDTO.java
@@ -18,4 +18,5 @@ public class ProductDTO {
   private Product.DeliveryChannel deliveryChannel;
   private List<Product.RequestChannel> requestChannels;
   private Product.Handler handler;
+  
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/ProductDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/ProductDTO.java
@@ -18,5 +18,4 @@ public class ProductDTO {
   private Product.DeliveryChannel deliveryChannel;
   private List<Product.RequestChannel> requestChannels;
   private Product.Handler handler;
-  
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/ProductDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/ProductDTO.java
@@ -16,6 +16,5 @@ public class ProductDTO {
   private Boolean individual;
   private List<Product.Region> regions;
   private Product.DeliveryChannel deliveryChannel;
-  private List<Product.RequestChannel> requestChannels;
   private Product.Handler handler;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/ProductDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/ProductDTO.java
@@ -1,0 +1,21 @@
+package uk.gov.ons.ctp.integration.rhsvc.representation;
+
+import java.util.List;
+import lombok.Data;
+import uk.gov.ons.ctp.integration.common.product.model.Product;
+
+@Data
+/** Representation of a Product omitting fields not needed by the RH UI */
+public class ProductDTO {
+
+  private String fulfilmentCode;
+  private Product.ProductGroup productGroup;
+  private String description;
+  private String language;
+  private List<Product.CaseType> caseTypes;
+  private Boolean individual;
+  private List<Product.Region> regions;
+  private Product.DeliveryChannel deliveryChannel;
+  private List<Product.RequestChannel> requestChannels;
+  private Product.Handler handler;
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/FulfilmentsService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/FulfilmentsService.java
@@ -9,6 +9,7 @@ import uk.gov.ons.ctp.integration.common.product.model.Product.Region;
 
 public interface FulfilmentsService {
 
-  List<Product> getFulfilments(CaseType caseType, Region region, DeliveryChannel deliveryChannel)
+  List<Product> getFulfilments(
+      List<CaseType> caseType, Region region, DeliveryChannel deliveryChannel, boolean individual)
       throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/FulfilmentsService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/FulfilmentsService.java
@@ -6,10 +6,11 @@ import uk.gov.ons.ctp.integration.common.product.model.Product;
 import uk.gov.ons.ctp.integration.common.product.model.Product.CaseType;
 import uk.gov.ons.ctp.integration.common.product.model.Product.DeliveryChannel;
 import uk.gov.ons.ctp.integration.common.product.model.Product.Region;
+import uk.gov.ons.ctp.integration.rhsvc.representation.ProductDTO;
 
 public interface FulfilmentsService {
 
-  List<Product> getFulfilments(
+  List<ProductDTO> getFulfilments(
       List<CaseType> caseType,
       Region region,
       DeliveryChannel deliveryChannel,

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/FulfilmentsService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/FulfilmentsService.java
@@ -10,6 +10,10 @@ import uk.gov.ons.ctp.integration.common.product.model.Product.Region;
 public interface FulfilmentsService {
 
   List<Product> getFulfilments(
-      List<CaseType> caseType, Region region, DeliveryChannel deliveryChannel, Boolean individual)
+      List<CaseType> caseType,
+      Region region,
+      DeliveryChannel deliveryChannel,
+      Product.ProductGroup productGroup,
+      Boolean individual)
       throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/FulfilmentsService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/FulfilmentsService.java
@@ -10,6 +10,6 @@ import uk.gov.ons.ctp.integration.common.product.model.Product.Region;
 public interface FulfilmentsService {
 
   List<Product> getFulfilments(
-      List<CaseType> caseType, Region region, DeliveryChannel deliveryChannel, boolean individual)
+      List<CaseType> caseType, Region region, DeliveryChannel deliveryChannel, Boolean individual)
       throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
@@ -220,7 +220,7 @@ public class CaseServiceImpl implements CaseService {
     // Create the event payload request
     FulfilmentRequest fulfilmentRequest = new FulfilmentRequest();
     fulfilmentRequest.setCaseId(caseDetails.getId());
-    boolean isIndividual = true;
+    boolean isIndividual = false;
     if (product.getIndividual() != null) {
       isIndividual = product.getIndividual();
     }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
@@ -197,7 +197,6 @@ public class CaseServiceImpl implements CaseService {
     log.with("region", region)
         .with("deliveryChannel", deliveryChannel)
         .with("fulfilmentCode", requestBodyDTO.getFulfilmentCode())
-        //        .with("individual", requestBodyDTO.getIndividual())
         .debug("Attempting to find product.");
 
     // Build search criteria base on the cases details and the requested fulfilmentCode
@@ -206,7 +205,6 @@ public class CaseServiceImpl implements CaseService {
     searchCriteria.setRegions(Arrays.asList(region));
     searchCriteria.setDeliveryChannel(deliveryChannel);
     searchCriteria.setFulfilmentCode(requestBodyDTO.getFulfilmentCode());
-    //    searchCriteria.setIndividual(requestBodyDTO.getIndividual());
 
     // Attempt to find matching product
     List<Product> products = productReference.searchProducts(searchCriteria);

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
@@ -219,7 +219,7 @@ public class CaseServiceImpl implements CaseService {
     // Create the event payload request
     FulfilmentRequest fulfilmentRequest = new FulfilmentRequest();
     fulfilmentRequest.setCaseId(caseDetails.getId());
-    if (product.getCaseType().equals(Product.CaseType.HI)) {
+    if (product.getCaseTypes().contains(Product.CaseType.HH) && product.isIndividual()) {
       fulfilmentRequest.setIndividualCaseId(UUID.randomUUID().toString());
     }
     fulfilmentRequest.setFulfilmentCode(product.getFulfilmentCode());

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImpl.java
@@ -20,7 +20,11 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
 
   @Override
   public List<Product> getFulfilments(
-      List<CaseType> caseTypes, Region region, DeliveryChannel deliveryChannel, Boolean individual)
+      List<CaseType> caseTypes,
+      Region region,
+      DeliveryChannel deliveryChannel,
+      Product.ProductGroup productGroup,
+      Boolean individual)
       throws CTPException {
 
     Product example = new Product();
@@ -29,6 +33,7 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
     example.setRegions(region == null ? null : Arrays.asList(region));
     example.setDeliveryChannel(deliveryChannel);
     example.setIndividual(individual);
+    example.setProductGroup(productGroup);
 
     List<Product> products = productReference.searchProducts(example);
 

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImpl.java
@@ -20,7 +20,7 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
 
   @Override
   public List<Product> getFulfilments(
-      List<CaseType> caseTypes, Region region, DeliveryChannel deliveryChannel, boolean individual)
+      List<CaseType> caseTypes, Region region, DeliveryChannel deliveryChannel, Boolean individual)
       throws CTPException {
 
     Product example = new Product();

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImpl.java
@@ -2,7 +2,6 @@ package uk.gov.ons.ctp.integration.rhsvc.service.impl;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,7 +20,7 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
 
   @Autowired ProductReference productReference;
 
-  @Autowired private MapperFacade mapperFacade;
+  @Autowired MapperFacade mapperFacade;
 
   @Override
   public List<ProductDTO> getFulfilments(
@@ -41,15 +40,6 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
     example.setProductGroup(productGroup);
 
     List<Product> products = productReference.searchProducts(example);
-
-    return products
-        .stream()
-        .map(
-            p -> {
-              ProductDTO dto = new ProductDTO();
-              mapperFacade.map(p, dto);
-              return dto;
-            })
-        .collect(Collectors.toList());
+    return mapperFacade.mapAsList(products, ProductDTO.class);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImpl.java
@@ -15,17 +15,20 @@ import uk.gov.ons.ctp.integration.rhsvc.service.FulfilmentsService;
 
 @Service
 public class FulfilmentsServiceImpl implements FulfilmentsService {
+
   @Autowired ProductReference productReference;
 
   @Override
   public List<Product> getFulfilments(
-      CaseType caseType, Region region, DeliveryChannel deliveryChannel) throws CTPException {
+      List<CaseType> caseTypes, Region region, DeliveryChannel deliveryChannel, boolean individual)
+      throws CTPException {
 
     Product example = new Product();
     example.setRequestChannels(Arrays.asList(RequestChannel.RH));
-    example.setCaseType(caseType);
+    example.setCaseTypes(caseTypes);
     example.setRegions(region == null ? null : Arrays.asList(region));
     example.setDeliveryChannel(deliveryChannel);
+    example.setIndividual(individual);
 
     List<Product> products = productReference.searchProducts(example);
 

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImpl.java
@@ -2,6 +2,8 @@ package uk.gov.ons.ctp.integration.rhsvc.service.impl;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -11,6 +13,7 @@ import uk.gov.ons.ctp.integration.common.product.model.Product.CaseType;
 import uk.gov.ons.ctp.integration.common.product.model.Product.DeliveryChannel;
 import uk.gov.ons.ctp.integration.common.product.model.Product.Region;
 import uk.gov.ons.ctp.integration.common.product.model.Product.RequestChannel;
+import uk.gov.ons.ctp.integration.rhsvc.representation.ProductDTO;
 import uk.gov.ons.ctp.integration.rhsvc.service.FulfilmentsService;
 
 @Service
@@ -18,8 +21,10 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
 
   @Autowired ProductReference productReference;
 
+  @Autowired private MapperFacade mapperFacade;
+
   @Override
-  public List<Product> getFulfilments(
+  public List<ProductDTO> getFulfilments(
       List<CaseType> caseTypes,
       Region region,
       DeliveryChannel deliveryChannel,
@@ -37,6 +42,14 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
 
     List<Product> products = productReference.searchProducts(example);
 
-    return products;
+    return products
+        .stream()
+        .map(
+            p -> {
+              ProductDTO dto = new ProductDTO();
+              mapperFacade.map(p, dto);
+              return dto;
+            })
+        .collect(Collectors.toList());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpointUnitTest.java
@@ -19,7 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.ons.ctp.common.error.RestExceptionHandler;
 import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
-import uk.gov.ons.ctp.integration.common.product.model.Product;
+import uk.gov.ons.ctp.integration.rhsvc.representation.ProductDTO;
 import uk.gov.ons.ctp.integration.rhsvc.service.FulfilmentsService;
 
 /**
@@ -51,7 +51,7 @@ public final class FulfilmentsEndpointUnitTest {
 
   @Test
   public void fulfilmentsReqestNoParameters() throws Exception {
-    List<Product> emptyList = new ArrayList<>();
+    List<ProductDTO> emptyList = new ArrayList<>();
     Mockito.when(fulfilmentsService.getFulfilments(any(), any(), any(), any(), anyBoolean()))
         .thenReturn(emptyList);
 
@@ -60,7 +60,7 @@ public final class FulfilmentsEndpointUnitTest {
 
   @Test
   public void fulfilmentsReqestAllParameters() throws Exception {
-    List<Product> emptyList = new ArrayList<>();
+    List<ProductDTO> emptyList = new ArrayList<>();
     Mockito.when(fulfilmentsService.getFulfilments(any(), any(), any(), any(), anyBoolean()))
         .thenReturn(emptyList);
 

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpointUnitTest.java
@@ -52,7 +52,7 @@ public final class FulfilmentsEndpointUnitTest {
   @Test
   public void fulfilmentsReqestNoParameters() throws Exception {
     List<Product> emptyList = new ArrayList<>();
-    Mockito.when(fulfilmentsService.getFulfilments(any(), any(), any(), anyBoolean()))
+    Mockito.when(fulfilmentsService.getFulfilments(any(), any(), any(), any(), anyBoolean()))
         .thenReturn(emptyList);
 
     mockMvc.perform(getJson("/fulfilments")).andExpect(status().isOk());
@@ -61,11 +61,13 @@ public final class FulfilmentsEndpointUnitTest {
   @Test
   public void fulfilmentsReqestAllParameters() throws Exception {
     List<Product> emptyList = new ArrayList<>();
-    Mockito.when(fulfilmentsService.getFulfilments(any(), any(), any(), anyBoolean()))
+    Mockito.when(fulfilmentsService.getFulfilments(any(), any(), any(), any(), anyBoolean()))
         .thenReturn(emptyList);
 
     mockMvc
-        .perform(getJson("/fulfilments?caseType=HH&region=E&deliveryChannel=SMS&individual=false"))
+        .perform(
+            getJson(
+                "/fulfilments?caseType=HH&region=E&deliveryChannel=SMS&individual=false&productGroup=UAC"))
         .andExpect(status().isOk());
   }
 
@@ -82,5 +84,10 @@ public final class FulfilmentsEndpointUnitTest {
   @Test
   public void fulfilmentsReqestWithInvalidDeliveryChannel() throws Exception {
     mockMvc.perform(getJson("/fulfilments?deliveryChannel=X")).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void fulfilmentsRequestWithInvalidProductGroup() throws Exception {
+    mockMvc.perform(getJson("/fulfilments?productGroup=XXX")).andExpect(status().isBadRequest());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpointUnitTest.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.integration.rhsvc.endpoint;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.ons.ctp.common.MvcHelper.getJson;
 import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
@@ -51,7 +52,8 @@ public final class FulfilmentsEndpointUnitTest {
   @Test
   public void fulfilmentsReqestNoParameters() throws Exception {
     List<Product> emptyList = new ArrayList<>();
-    Mockito.when(fulfilmentsService.getFulfilments(any(), any(), any())).thenReturn(emptyList);
+    Mockito.when(fulfilmentsService.getFulfilments(any(), any(), any(), anyBoolean()))
+        .thenReturn(emptyList);
 
     mockMvc.perform(getJson("/fulfilments")).andExpect(status().isOk());
   }
@@ -59,10 +61,11 @@ public final class FulfilmentsEndpointUnitTest {
   @Test
   public void fulfilmentsReqestAllParameters() throws Exception {
     List<Product> emptyList = new ArrayList<>();
-    Mockito.when(fulfilmentsService.getFulfilments(any(), any(), any())).thenReturn(emptyList);
+    Mockito.when(fulfilmentsService.getFulfilments(any(), any(), any(), anyBoolean()))
+        .thenReturn(emptyList);
 
     mockMvc
-        .perform(getJson("/fulfilments?caseType=HI&region=E&deliveryChannel=SMS"))
+        .perform(getJson("/fulfilments?caseType=HH&region=E&deliveryChannel=SMS"))
         .andExpect(status().isOk());
   }
 

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpointUnitTest.java
@@ -65,7 +65,7 @@ public final class FulfilmentsEndpointUnitTest {
         .thenReturn(emptyList);
 
     mockMvc
-        .perform(getJson("/fulfilments?caseType=HH&region=E&deliveryChannel=SMS"))
+        .perform(getJson("/fulfilments?caseType=HH&region=E&deliveryChannel=SMS&individual=false"))
         .andExpect(status().isOk());
   }
 

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplTest.java
@@ -238,7 +238,9 @@ public class CaseServiceImplTest {
 
   @Test
   public void testFulfilmentRequestBySMS_Household() throws Exception {
-    FulfilmentRequest actualFulfilmentRequest = doFulfilmentRequestBySMS(Product.CaseType.HH);
+    Boolean b;
+    FulfilmentRequest actualFulfilmentRequest =
+        doFulfilmentRequestBySMS(Product.CaseType.HH, false);
 
     // Individual case id field should not be set for non-individual
     assertNull(actualFulfilmentRequest.getIndividualCaseId());
@@ -246,7 +248,7 @@ public class CaseServiceImplTest {
 
   @Test
   public void testFulfilmentRequestBySMS_Individual() throws Exception {
-    FulfilmentRequest actualFulfilmentRequest = doFulfilmentRequestBySMS(Product.CaseType.HI);
+    FulfilmentRequest actualFulfilmentRequest = doFulfilmentRequestBySMS(Product.CaseType.HH, true);
 
     // Individual case id field should be populated as case+product is for an individual
     String individualUuid = actualFulfilmentRequest.getIndividualCaseId();
@@ -255,6 +257,11 @@ public class CaseServiceImplTest {
   }
 
   private FulfilmentRequest doFulfilmentRequestBySMS(Product.CaseType caseType) throws Exception {
+    return doFulfilmentRequestBySMS(caseType, false);
+  }
+
+  private FulfilmentRequest doFulfilmentRequestBySMS(Product.CaseType caseType, boolean individual)
+      throws Exception {
     // Setup case data with required case type
     CollectionCase caseDetails = collectionCase.get(0);
     caseDetails.getAddress().setAddressType(caseType.toString());
@@ -269,12 +276,13 @@ public class CaseServiceImplTest {
     expectedSearchProduct.setRegions(Arrays.asList(Product.Region.E));
     expectedSearchProduct.setDeliveryChannel(DeliveryChannel.SMS);
     expectedSearchProduct.setFulfilmentCode("F1");
+    expectedSearchProduct.setIndividual(individual);
 
     // Simulate the behaviour of the ProductReference
     Product product = new Product();
-    product.setCaseType(Product.CaseType.HH);
     product.setFulfilmentCode("F1");
-    product.setCaseType(caseType);
+    product.setCaseTypes(caseType.toList());
+    product.setIndividual(individual);
     List<Product> foundProducts = new ArrayList<>();
     foundProducts.add(product);
     when(productReference.searchProducts(eq(expectedSearchProduct))).thenReturn(foundProducts);

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplTest.java
@@ -288,7 +288,7 @@ public class CaseServiceImplTest {
     // Simulate the behaviour of the ProductReference
     Product productToReturn = new Product();
     productToReturn.setFulfilmentCode("F1");
-    productToReturn.setCaseTypes(caseType.toList());
+    productToReturn.setCaseTypes(Arrays.asList(caseType));
     productToReturn.setIndividual(individual);
     List<Product> foundProducts = new ArrayList<>();
     foundProducts.add(productToReturn);

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
@@ -3,28 +3,29 @@ package uk.gov.ons.ctp.integration.rhsvc.service.impl;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import ma.glasnost.orika.MapperFacade;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ons.ctp.integration.common.product.ProductReference;
 import uk.gov.ons.ctp.integration.common.product.model.Product;
 import uk.gov.ons.ctp.integration.common.product.model.Product.CaseType;
 import uk.gov.ons.ctp.integration.common.product.model.Product.DeliveryChannel;
 import uk.gov.ons.ctp.integration.common.product.model.Product.Region;
 import uk.gov.ons.ctp.integration.common.product.model.Product.RequestChannel;
+import uk.gov.ons.ctp.integration.rhsvc.RHSvcBeanMapper;
 import uk.gov.ons.ctp.integration.rhsvc.representation.ProductDTO;
 
+@RunWith(MockitoJUnitRunner.class)
 public class FulfilmentsServiceImplTest {
 
   @Mock ProductReference productReference;
+
+  @Spy private MapperFacade mapperFacade = new RHSvcBeanMapper();
 
   @InjectMocks FulfilmentsServiceImpl fulfilmentsService;
 
@@ -38,7 +39,14 @@ public class FulfilmentsServiceImplTest {
   @Test
   public void testFulfilmentsQuery() throws Exception {
     // Mock the behaviour of the Product Reference
-    List<Product> mockedResults = new ArrayList<>();
+    Product product =
+        Product.builder()
+            .caseTypes(Arrays.asList(CaseType.HH))
+            .regions(Arrays.asList(Region.E))
+            .deliveryChannel(DeliveryChannel.SMS)
+            .productGroup(Product.ProductGroup.UAC)
+            .build();
+    List<Product> mockedResults = Arrays.asList(product);
     Mockito.when(productReference.searchProducts(any())).thenReturn(mockedResults);
 
     // Invoke the method under test
@@ -75,7 +83,19 @@ public class FulfilmentsServiceImplTest {
     assertNull(capturedExampleProduct.getLanguage());
     assertNull(capturedExampleProduct.getHandler());
 
-    // Verify that getFulfilments() returns the value it got from the ProductReference search
-    assertEquals(mockedResults, products);
+    // ACTUALLY verify that getFulfilments() returns the value it got from the ProductReference
+    // search
+    assertEquals(1, products.size());
+    ProductDTO theResult = products.get(0);
+
+    assertEquals(product.getIndividual(), theResult.getIndividual());
+    assertEquals(product.getCaseTypes(), theResult.getCaseTypes());
+    assertEquals(product.getDeliveryChannel(), theResult.getDeliveryChannel());
+    assertEquals(product.getDescription(), theResult.getDescription());
+    assertEquals(product.getFulfilmentCode(), theResult.getFulfilmentCode());
+    assertEquals(product.getLanguage(), theResult.getLanguage());
+    assertEquals(product.getProductGroup(), theResult.getProductGroup());
+    assertEquals(product.getRegions(), theResult.getRegions());
+    assertEquals(product.getHandler(), theResult.getHandler());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +44,11 @@ public class FulfilmentsServiceImplTest {
     // Invoke the method under test
     List<ProductDTO> products =
         fulfilmentsService.getFulfilments(
-            CaseType.HH.toList(), Region.E, DeliveryChannel.SMS, Product.ProductGroup.UAC, true);
+            Arrays.asList(CaseType.HH),
+            Region.E,
+            DeliveryChannel.SMS,
+            Product.ProductGroup.UAC,
+            true);
 
     // Get hold of the example product used in the search
     Mockito.verify(productReference).searchProducts(exampleProductCaptor.capture());

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.integration.rhsvc.service.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 
 import java.util.ArrayList;
@@ -42,7 +41,8 @@ public class FulfilmentsServiceImplTest {
 
     // Invoke the method under test
     List<Product> products =
-        fulfilmentsService.getFulfilments(CaseType.HI, Region.E, DeliveryChannel.SMS);
+        fulfilmentsService.getFulfilments(
+            CaseType.HH.toList(), Region.E, DeliveryChannel.SMS, false);
 
     // Get hold of the example product used in the search
     Mockito.verify(productReference).searchProducts(exampleProductCaptor.capture());
@@ -53,7 +53,7 @@ public class FulfilmentsServiceImplTest {
     assertEquals(RequestChannel.RH, capturedExampleProduct.getRequestChannels().get(0));
 
     // Verify the parameters are used in the product search
-    assertEquals(CaseType.HI, capturedExampleProduct.getCaseType());
+    assertTrue(capturedExampleProduct.getCaseTypes().contains(CaseType.HH));
     assertEquals(1, capturedExampleProduct.getRegions().size());
     assertEquals(Region.E, capturedExampleProduct.getRegions().get(0));
     assertEquals(DeliveryChannel.SMS, capturedExampleProduct.getDeliveryChannel());

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
@@ -19,6 +19,7 @@ import uk.gov.ons.ctp.integration.common.product.model.Product.CaseType;
 import uk.gov.ons.ctp.integration.common.product.model.Product.DeliveryChannel;
 import uk.gov.ons.ctp.integration.common.product.model.Product.Region;
 import uk.gov.ons.ctp.integration.common.product.model.Product.RequestChannel;
+import uk.gov.ons.ctp.integration.rhsvc.representation.ProductDTO;
 
 public class FulfilmentsServiceImplTest {
 
@@ -40,7 +41,7 @@ public class FulfilmentsServiceImplTest {
     Mockito.when(productReference.searchProducts(any())).thenReturn(mockedResults);
 
     // Invoke the method under test
-    List<Product> products =
+    List<ProductDTO> products =
         fulfilmentsService.getFulfilments(
             CaseType.HH.toList(), Region.E, DeliveryChannel.SMS, Product.ProductGroup.UAC, true);
 

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/FulfilmentsServiceImplTest.java
@@ -42,7 +42,7 @@ public class FulfilmentsServiceImplTest {
     // Invoke the method under test
     List<Product> products =
         fulfilmentsService.getFulfilments(
-            CaseType.HH.toList(), Region.E, DeliveryChannel.SMS, false);
+            CaseType.HH.toList(), Region.E, DeliveryChannel.SMS, Product.ProductGroup.UAC, true);
 
     // Get hold of the example product used in the search
     Mockito.verify(productReference).searchProducts(exampleProductCaptor.capture());
@@ -57,6 +57,8 @@ public class FulfilmentsServiceImplTest {
     assertEquals(1, capturedExampleProduct.getRegions().size());
     assertEquals(Region.E, capturedExampleProduct.getRegions().get(0));
     assertEquals(DeliveryChannel.SMS, capturedExampleProduct.getDeliveryChannel());
+    assertTrue(capturedExampleProduct.getIndividual());
+    assertEquals(Product.ProductGroup.UAC, capturedExampleProduct.getProductGroup());
 
     // Verify that nothing else was specified in the product search
     assertNull(capturedExampleProduct.getFulfilmentCode());


### PR DESCRIPTION
# Motivation and Context
The UI can now search for cases using multiple case types and product group. Additionally, we can search.by whether cases are for individuals or not. These new parameters are all now handled in the RH service.

In addition, a Product DTO containing a subset of Product fields is now returned to the UI. 

# What has changed
The fulfilment endpoint and service, and the case service have all changed to allow for the new parameters. 
Unit tests for these classes have been modified to accommodate the changes. 

# How to test?
The UI is being modified to consume these changes. We will co-ordinate these changes and the UI to ensure they play nicely in dev.

# Links
[This PR](https://github.com/ONSdigital/census-int-product-reference/pull/7) and [this one](https://github.com/ONSdigital/census-int-common-test-framework/pull/6) contain related changes to the models and the test framework.
