### PR TITLE
Adding support for the formType field on UAC events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.23</version>
+      <version>0.0.24-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.24-SNAPSHOT</version>
+      <version>0.0.24</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/UniqueAccessCodeDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/UniqueAccessCodeDTO.java
@@ -23,4 +23,5 @@ public class UniqueAccessCodeDTO {
   private UUID caseId;
   private UUID collectionExerciseId;
   private AddressDTO address;
+  private String formType;
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplUnit_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplUnit_Test.java
@@ -34,14 +34,7 @@ public class UacEventReceiverImplUnit_Test {
     UACEvent uacEventFixture = new UACEvent();
     UACPayload uacPayloadFixture = uacEventFixture.getPayload();
     UAC uacFixture = uacPayloadFixture.getUac();
-    uacFixture.setUacHash("999999999");
-    uacFixture.setActive("true");
-    uacFixture.setQuestionnaireId("1110000009");
-    uacFixture.setCaseType("H");
-    uacFixture.setRegion("E");
-    uacFixture.setCaseId("c45de4dc-3c3b-11e9-b210-d663bd873d93");
-    uacFixture.setCollectionExerciseId("n66de4dc-3c3b-11e9-b210-d663bd873d93");
-    uacFixture.setFormType("H");
+
     Header headerFixture = new Header();
     headerFixture.setType(EventType.UAC_UPDATED);
     headerFixture.setTransactionId("c45de4dc-3c3b-11e9-b210-d663bd873d93");

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplUnit_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplUnit_Test.java
@@ -41,6 +41,7 @@ public class UacEventReceiverImplUnit_Test {
     uacFixture.setRegion("E");
     uacFixture.setCaseId("c45de4dc-3c3b-11e9-b210-d663bd873d93");
     uacFixture.setCollectionExerciseId("n66de4dc-3c3b-11e9-b210-d663bd873d93");
+    uacFixture.setFormType("H");
     Header headerFixture = new Header();
     headerFixture.setType(EventType.UAC_UPDATED);
     headerFixture.setTransactionId("c45de4dc-3c3b-11e9-b210-d663bd873d93");

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
@@ -86,6 +86,7 @@ public class UniqueAccessCodeServiceImplTest {
     assertEquals(uacTest.getQuestionnaireId(), uacDTO.getQuestionnaireId());
     assertEquals(uacTest.getCaseType(), uacDTO.getCaseType());
     assertEquals(uacTest.getRegion(), uacDTO.getRegion());
+    assertEquals(uacTest.getFormType(), uacDTO.getFormType());
 
     assertEquals(caseTest.getAddress().getAddressLine1(), uacDTO.getAddress().getAddressLine1());
     assertEquals(caseTest.getAddress().getAddressLine2(), uacDTO.getAddress().getAddressLine2());

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.UAC.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.UAC.json
@@ -5,5 +5,6 @@
 	"caseType": "HH",
 	"region": "E",
 	"caseId": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4",
-	"collectionExerciseId": "a66de4dc-3c3b-11e9-b210-d663bd873d93"
+	"collectionExerciseId": "a66de4dc-3c3b-11e9-b210-d663bd873d93",
+	"formType": "H"
 } 


### PR DESCRIPTION
# Motivation and Context
A new field, formType has been added to UAC events. This change accommodates the new field when inbound, and ensures it is included on responses from the Unique Access Code endpoint.

# What has changed
The new field has been added to a fixture used for tests, and to the DTO being sent back to the UI. Existing unit tests have been extended to cover this field.

# How to test?
The UI suite will verify.

# Links
[This PR](https://github.com/ONSdigital/census-int-event-publisher/pull/20) is related as it provides the field in the relevant event type.
