### PR TITLE
Adding support for handDelivery to cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.25</version>      
+      <version>0.0.27-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.27-SNAPSHOT</version>
+      <version>0.0.27</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/UniqueAccessCodeDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/UniqueAccessCodeDTO.java
@@ -24,4 +24,5 @@ public class UniqueAccessCodeDTO {
   private UUID collectionExerciseId;
   private AddressDTO address;
   private String formType;
+  private boolean handDelivery;
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/UniqueAccessCodeEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/UniqueAccessCodeEndpointTest.java
@@ -62,7 +62,8 @@ public class UniqueAccessCodeEndpointTest {
         .andExpect(content().contentType("application/json;charset=UTF-8"))
         .andExpect(jsonPath("$.uacHash", is(UAC_HASH)))
         .andExpect(jsonPath("$.caseId", is(CASE_ID)))
-        .andExpect(jsonPath("$.address.postcode", is(POSTCODE)));
+        .andExpect(jsonPath("$.address.postcode", is(POSTCODE)))
+        .andExpect(jsonPath("$.handDelivery", is(true)));
   }
 
   /** Test returns resource not found for invalid UAC */

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/CaseEventReceiverImplIT_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/CaseEventReceiverImplIT_Test.java
@@ -104,6 +104,7 @@ public class CaseEventReceiverImplIT_Test {
     collectionCase.setSurvey("Census");
     collectionCase.setCollectionExerciseId("n66de4dc-3c3b-11e9-b210-d663bd873d93");
     collectionCase.setActionableFrom("2011-08-12T20:17:46.384Z");
+    collectionCase.setHandDelivery(true);
 
     Address address = collectionCase.getAddress();
     address.setAddressLine1("1 main street");
@@ -130,6 +131,7 @@ public class CaseEventReceiverImplIT_Test {
     header.setDateTime(new Date());
     header.setTransactionId("c45de4dc-3c3b-11e9-b210-d663bd873d93");
     caseEvent.setEvent(header);
+
     return caseEvent;
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RespondentDataRepositoryIT_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RespondentDataRepositoryIT_Test.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.integration.rhsvc.repository.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Optional;
 import org.junit.Before;
@@ -63,6 +64,7 @@ public class RespondentDataRepositoryIT_Test {
     collectionCase.setAddress(address);
     collectionCase.setContact(contact);
     collectionCase.setActionableFrom(actionableFrom);
+    collectionCase.setHandDelivery(true);
 
     uac = new UAC();
     uac.setUacHash(uacHash);
@@ -103,5 +105,6 @@ public class RespondentDataRepositoryIT_Test {
     assertEquals(collectionCase.getAddress(), collectionCase2.getAddress());
     assertEquals(collectionCase.getContact(), collectionCase2.getContact());
     assertEquals(collectionCase.getActionableFrom(), collectionCase2.getActionableFrom());
+    assertTrue(collectionCase.isHandDelivery());
   }
 }

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/endpoint/UniqueAccessCodeEndpointTest.UniqueAccessCodeDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/endpoint/UniqueAccessCodeEndpointTest.UniqueAccessCodeDTO.json
@@ -6,6 +6,7 @@
 	"region": "E",
 	"caseId": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4",
 	"collectionExerciseId": "a66de4dc-3c3b-11e9-b210-d663bd873d93",
+	"handDelivery": true,
 	"address": {
 		"addressLine1": "1 main street",
 		"addressLine2": "upper upperingham",


### PR DESCRIPTION
# Motivation and Context
A new field on certain events is being added by RM

# What has changed
The UniqueAccessCodeDTO and attendant services have had the field added
Unit tests have been modified to ensure the new field is both present and perpetuated.

# How to test?
The new field will ultimately be surfaced in the RH UI.


