### PR TITLE
CR-785. Filter QID prefixes 11-14

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcApplication.java
@@ -29,16 +29,12 @@ import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
 @ImportResource("springintegration/main.xml")
 public class RHSvcApplication {
 
-  @Value("${queueconfig.event-exchange}")
-  private String eventExchange;
-
   /**
    * The main entry point for this application.
    *
    * @param args runtime command line args
    */
   public static void main(final String[] args) {
-
     SpringApplication.run(RHSvcApplication.class, args);
   }
 

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/AppConfig.java
@@ -13,4 +13,5 @@ import org.springframework.retry.annotation.EnableRetry;
 public class AppConfig {
   private SwaggerSettings swaggerSettings;
   private Logging logging;
+  private QueueConfig queueConfig;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/QueueConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/QueueConfig.java
@@ -1,0 +1,18 @@
+package uk.gov.ons.ctp.integration.rhsvc.config;
+
+import java.util.Set;
+import lombok.Data;
+
+@Data
+public class QueueConfig {
+  private String eventExchange;
+  private String deadLetterExchange;
+  private String caseQueue;
+  private String caseQueueDLQ;
+  private String caseRoutingKey;
+  private String uacQueue;
+  private String uacQueueDLQ;
+  private String uacRoutingKey;
+  private String responseAuthenticationRoutingKey;
+  private Set<String> qidFilterPrefixes;
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/event/impl/CaseEventReceiverImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/event/impl/CaseEventReceiverImpl.java
@@ -24,8 +24,9 @@ import uk.gov.ons.ctp.integration.rhsvc.repository.RespondentDataRepository;
 @MessageEndpoint
 public class CaseEventReceiverImpl implements CaseEventReceiver {
 
-  @Autowired private RespondentDataRepository respondentDataRepo;
   private static final Logger log = LoggerFactory.getLogger(CaseEventReceiverImpl.class);
+
+  @Autowired private RespondentDataRepository respondentDataRepo;
 
   /**
    * Message end point for events from Response Management.

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/event/impl/UACEventReceiverImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/event/impl/UACEventReceiverImpl.java
@@ -24,8 +24,9 @@ import uk.gov.ons.ctp.integration.rhsvc.repository.RespondentDataRepository;
 @MessageEndpoint
 public class UACEventReceiverImpl {
 
-  @Autowired private RespondentDataRepository respondentDataRepo;
   private static final Logger log = LoggerFactory.getLogger(UACEventReceiverImpl.class);
+
+  @Autowired private RespondentDataRepository respondentDataRepo;
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/event/impl/UACEventReceiverImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/event/impl/UACEventReceiverImpl.java
@@ -2,17 +2,16 @@ package uk.gov.ons.ctp.integration.rhsvc.event.impl;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.model.UAC;
 import uk.gov.ons.ctp.common.event.model.UACEvent;
+import uk.gov.ons.ctp.integration.rhsvc.config.AppConfig;
 import uk.gov.ons.ctp.integration.rhsvc.repository.RespondentDataRepository;
 
 /**
@@ -28,8 +27,7 @@ public class UACEventReceiverImpl {
   @Autowired private RespondentDataRepository respondentDataRepo;
   private static final Logger log = LoggerFactory.getLogger(UACEventReceiverImpl.class);
 
-  @Value("#{'${queueconfig.qid-filter-prefixes}'.split(',')}")
-  private List<String> qidFilterPrefixes;
+  @Autowired private AppConfig appConfig;
 
   /**
    * Message end point for events from Response Management. At present sends straight to publisher
@@ -66,6 +64,8 @@ public class UACEventReceiverImpl {
   }
 
   private boolean isFilteredByQid(String qid) {
-    return qid != null && qid.length() > 2 && qidFilterPrefixes.contains(qid.substring(0, 2));
+    return qid != null
+        && qid.length() > 2
+        && appConfig.getQueueConfig().getQidFilterPrefixes().contains(qid.substring(0, 2));
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/SurveyLaunchedServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/SurveyLaunchedServiceImpl.java
@@ -3,7 +3,6 @@ package uk.gov.ons.ctp.integration.rhsvc.service.impl;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -21,9 +20,6 @@ public class SurveyLaunchedServiceImpl implements SurveyLaunchedService {
   private static final Logger log = LoggerFactory.getLogger(SurveyLaunchedServiceImpl.class);
 
   @Autowired private EventPublisher eventPublisher;
-
-  @Value("${queueconfig.response-authentication-routing-key}")
-  private String routingKey;
 
   @Override
   public void surveyLaunched(SurveyLaunchedDTO surveyLaunchedDTO) throws CTPException {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -113,7 +113,11 @@ queueconfig:
   uac-queue-DLQ: case.rh.uac.dlq
   uac-routing-key: event.uac.update
   response-authentication-routing-key: event.response.authentication
-  qid-filter-prefixes: 11,12,13,14
+  qid-filter-prefixes:
+     - 11
+     - 12
+     - 13
+     - 14
 
 messaging:
   mismatchedQueuesFatal: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -113,6 +113,7 @@ queueconfig:
   uac-queue-DLQ: case.rh.uac.dlq
   uac-routing-key: event.uac.update
   response-authentication-routing-key: event.response.authentication
+  qid-filter-prefixes: 11,12,13,14
 
 messaging:
   mismatchedQueuesFatal: true

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/RespondentHomeFixture.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/RespondentHomeFixture.java
@@ -1,0 +1,18 @@
+package uk.gov.ons.ctp.integration.rhsvc;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RespondentHomeFixture {
+
+  public static final String QID_01 = "0130000003130730";
+  public static final String QID_11 = "1130000001203937";
+  public static final String QID_12 = "1230000003125553";
+  public static final String QID_13 = "1330000000000124";
+  public static final String QID_14 = "1430000001539033";
+  public static final String QID_21 = "2130000001529907";
+  public static final String QID_31 = "3130000002100533";
+
+  public static final String A_QID = QID_01;
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/CaseEventReceiverImplIT_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/CaseEventReceiverImplIT_Test.java
@@ -30,12 +30,13 @@ import uk.gov.ons.ctp.common.event.model.CasePayload;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
 import uk.gov.ons.ctp.common.event.model.Contact;
 import uk.gov.ons.ctp.common.event.model.Header;
+import uk.gov.ons.ctp.integration.rhsvc.config.AppConfig;
 import uk.gov.ons.ctp.integration.rhsvc.event.impl.CaseEventReceiverImpl;
 import uk.gov.ons.ctp.integration.rhsvc.repository.impl.RespondentDataRepositoryImpl;
 
 /** Spring Integration test of flow received from Response Management */
 @SpringBootTest
-@ContextConfiguration("/caseEventReceiverImpl.xml")
+@ContextConfiguration(value = "/caseEventReceiverImpl.xml", classes = AppConfig.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles("mocked-connection-factory")
 public class CaseEventReceiverImplIT_Test {

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/EventReceiverConfiguration.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/EventReceiverConfiguration.java
@@ -14,6 +14,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.ons.ctp.integration.rhsvc.config.AppConfig;
 import uk.gov.ons.ctp.integration.rhsvc.event.impl.CaseEventReceiverImpl;
 import uk.gov.ons.ctp.integration.rhsvc.event.impl.UACEventReceiverImpl;
 
@@ -41,8 +43,10 @@ public class EventReceiverConfiguration {
 
   /** Spy on Service Activator Message End point */
   @Bean
-  public UACEventReceiverImpl uacEventReceiver() {
-    return Mockito.spy(new UACEventReceiverImpl());
+  public UACEventReceiverImpl uacEventReceiver(AppConfig appConfig) {
+    UACEventReceiverImpl receiver = new UACEventReceiverImpl();
+    ReflectionTestUtils.setField(receiver, "appConfig", appConfig);
+    return Mockito.spy(receiver);
   }
 
   @Bean

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplIT_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplIT_Test.java
@@ -20,6 +20,7 @@ import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -31,12 +32,14 @@ import uk.gov.ons.ctp.common.event.model.UAC;
 import uk.gov.ons.ctp.common.event.model.UACEvent;
 import uk.gov.ons.ctp.common.event.model.UACPayload;
 import uk.gov.ons.ctp.integration.rhsvc.RespondentHomeFixture;
+import uk.gov.ons.ctp.integration.rhsvc.config.AppConfig;
 import uk.gov.ons.ctp.integration.rhsvc.event.impl.UACEventReceiverImpl;
 import uk.gov.ons.ctp.integration.rhsvc.repository.impl.RespondentDataRepositoryImpl;
 
 /** Spring Integration test of flow received from Response Management */
 @SpringBootTest
-@ContextConfiguration("/uacEventReceiverImpl.xml")
+@EnableConfigurationProperties
+@ContextConfiguration(value = "/uacEventReceiverImpl.xml", classes = AppConfig.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles("mocked-connection-factory")
 public class UacEventReceiverImplIT_Test {

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplUnit_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplUnit_Test.java
@@ -1,14 +1,20 @@
 package uk.gov.ons.ctp.integration.rhsvc.message.impl;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
 import uk.gov.ons.ctp.common.event.model.Header;
 import uk.gov.ons.ctp.common.event.model.UAC;
 import uk.gov.ons.ctp.common.event.model.UACEvent;
 import uk.gov.ons.ctp.common.event.model.UACPayload;
+import uk.gov.ons.ctp.integration.rhsvc.RespondentHomeFixture;
 import uk.gov.ons.ctp.integration.rhsvc.event.impl.UACEventReceiverImpl;
 import uk.gov.ons.ctp.integration.rhsvc.repository.RespondentDataRepository;
 import uk.gov.ons.ctp.integration.rhsvc.repository.impl.RespondentDataRepositoryImpl;
@@ -17,23 +23,24 @@ public class UacEventReceiverImplUnit_Test {
 
   private RespondentDataRepository mockRespondentDataRepo;
   private UACEventReceiverImpl target;
+  private UACEvent uacEventFixture;
+  private UAC uacFixture;
 
   @Before
   public void setUp() {
-
     target = new UACEventReceiverImpl();
-
-    mockRespondentDataRepo = Mockito.mock(RespondentDataRepositoryImpl.class);
+    ReflectionTestUtils.setField(
+        target, "qidFilterPrefixes", Arrays.asList("11", "12", "13", "14"));
+    mockRespondentDataRepo = mock(RespondentDataRepositoryImpl.class);
     target.setRespondentDataRepo(mockRespondentDataRepo);
   }
 
-  @Test
-  public void test_acceptUACEvent_success() throws CTPException {
-
+  private void prepareAndAcceptEvent(String qid) throws CTPException {
     // Construct UACEvent
-    UACEvent uacEventFixture = new UACEvent();
+    uacEventFixture = new UACEvent();
     UACPayload uacPayloadFixture = uacEventFixture.getPayload();
-    UAC uacFixture = uacPayloadFixture.getUac();
+    uacFixture = uacPayloadFixture.getUac();
+    uacFixture.setQuestionnaireId(qid);
 
     Header headerFixture = new Header();
     headerFixture.setType(EventType.UAC_UPDATED);
@@ -42,8 +49,50 @@ public class UacEventReceiverImplUnit_Test {
 
     // execution
     target.acceptUACEvent(uacEventFixture);
+  }
 
-    // verification
-    Mockito.verify(mockRespondentDataRepo).writeUAC(uacFixture);
+  private void acceptUacEvent(String qid) throws CTPException {
+    prepareAndAcceptEvent(qid);
+    verify(mockRespondentDataRepo).writeUAC(uacFixture);
+  }
+
+  private void filterUacEvent(String qid) throws CTPException {
+    prepareAndAcceptEvent(qid);
+    verify(mockRespondentDataRepo, never()).writeUAC(uacFixture);
+  }
+
+  @Test
+  public void shouldAcceptUacEventPrefix01() throws CTPException {
+    acceptUacEvent(RespondentHomeFixture.QID_01);
+  }
+
+  @Test
+  public void shouldAcceptUacEventPrefix21() throws CTPException {
+    acceptUacEvent(RespondentHomeFixture.QID_21);
+  }
+
+  @Test
+  public void shouldAcceptUacEventPrefix31() throws CTPException {
+    acceptUacEvent(RespondentHomeFixture.QID_31);
+  }
+
+  @Test
+  public void shouldFilterUacEventPrefix11() throws CTPException {
+    filterUacEvent(RespondentHomeFixture.QID_11);
+  }
+
+  @Test
+  public void shouldFilterUacEventPrefix12() throws CTPException {
+    filterUacEvent(RespondentHomeFixture.QID_12);
+  }
+
+  @Test
+  public void shouldFilterUacEventPrefix13() throws CTPException {
+    filterUacEvent(RespondentHomeFixture.QID_13);
+  }
+
+  @Test
+  public void shouldFilterUacEventPrefix14() throws CTPException {
+    filterUacEvent(RespondentHomeFixture.QID_14);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplUnit_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplUnit_Test.java
@@ -4,7 +4,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -15,6 +16,8 @@ import uk.gov.ons.ctp.common.event.model.UAC;
 import uk.gov.ons.ctp.common.event.model.UACEvent;
 import uk.gov.ons.ctp.common.event.model.UACPayload;
 import uk.gov.ons.ctp.integration.rhsvc.RespondentHomeFixture;
+import uk.gov.ons.ctp.integration.rhsvc.config.AppConfig;
+import uk.gov.ons.ctp.integration.rhsvc.config.QueueConfig;
 import uk.gov.ons.ctp.integration.rhsvc.event.impl.UACEventReceiverImpl;
 import uk.gov.ons.ctp.integration.rhsvc.repository.RespondentDataRepository;
 import uk.gov.ons.ctp.integration.rhsvc.repository.impl.RespondentDataRepositoryImpl;
@@ -25,12 +28,15 @@ public class UacEventReceiverImplUnit_Test {
   private UACEventReceiverImpl target;
   private UACEvent uacEventFixture;
   private UAC uacFixture;
+  private AppConfig appConfig = new AppConfig();
 
   @Before
   public void setUp() {
     target = new UACEventReceiverImpl();
-    ReflectionTestUtils.setField(
-        target, "qidFilterPrefixes", Arrays.asList("11", "12", "13", "14"));
+    QueueConfig queueConfig = new QueueConfig();
+    queueConfig.setQidFilterPrefixes(Stream.of("11", "12", "13", "14").collect(Collectors.toSet()));
+    appConfig.setQueueConfig(queueConfig);
+    ReflectionTestUtils.setField(target, "appConfig", appConfig);
     mockRespondentDataRepo = mock(RespondentDataRepositoryImpl.class);
     target.setRespondentDataRepo(mockRespondentDataRepo);
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RespondentDataRepositoryIT_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RespondentDataRepositoryIT_Test.java
@@ -10,6 +10,7 @@ import uk.gov.ons.ctp.common.event.model.Address;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
 import uk.gov.ons.ctp.common.event.model.Contact;
 import uk.gov.ons.ctp.common.event.model.UAC;
+import uk.gov.ons.ctp.integration.rhsvc.RespondentHomeFixture;
 import uk.gov.ons.ctp.integration.rhsvc.repository.RespondentDataRepository;
 
 // import uk.gov.ons.ctp.integration.rhsvc.domain.model.Address;
@@ -33,7 +34,7 @@ public class RespondentDataRepositoryIT_Test {
     String collectionExerciseId = "n66de4dc-3c3b-11e9-b210-d663bd873d93";
     String actionableFrom = "2011-08-12T20:17:46.384Z";
     String active = "true";
-    String questionnaireId = "1110000009";
+    String questionnaireId = RespondentHomeFixture.A_QID;
     String caseType = "H";
     String region = "E";
     Address address = new Address();


### PR DESCRIPTION
# Motivation and Context
QID's will be generated for continuation forms in RM and these will come across in the UACUpdated Event and they need to be filtered out as they won't ever be used for the online collection.
They won't contain attributes such as form type etc so we won't be able to store them etc.

All QID's that start 11,12, 13 & 14 are to be filtered.

# What has changed
* The QID prefixes for filtering are in application.yml.
* The code accepting the UAC looks for the questionnaire prefix and filters based on that.
* Unit tests are updated to test, including a using realistic fixture values, based on WhiteLodge values in firestore.
* Cucumber tests have been altered in a different PR to choose a non-filtered QID
* EventGenerator has been altered in a different PR to choose a non-filtered QID

