### PR TITLE
Cr 871 add uac created event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,13 +113,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.51</version>
+      <version>0.0.52</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.28-SNAPSHOT</version>
+      <version>0.0.28</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-sleuth-zipkin -->
-    <!-- <dependency> <groupId>org.springframework.cloud</groupId> <artifactId>spring-cloud-sleuth-zipkin</artifactId> 
+    <!-- <dependency> <groupId>org.springframework.cloud</groupId> <artifactId>spring-cloud-sleuth-zipkin</artifactId>
       </dependency> -->
 
     <!-- If you intend to deploy the app on Cloud Foundry, add the following -->
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.27</version>
+      <version>0.0.28-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -175,7 +175,6 @@
     <dependency>
       <groupId>com.sun.xml.messaging.saaj</groupId>
       <artifactId>saaj-impl</artifactId>
-      <version>1.5.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/event/impl/UACEventReceiverImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/event/impl/UACEventReceiverImpl.java
@@ -34,7 +34,7 @@ public class UACEventReceiverImpl {
    * Message end point for events from Response Management. At present sends straight to publisher
    * to prove messaging setup.
    *
-   * @param uacEvent UACEvent message from Response Management
+   * @param uacEvent UACEvent message (either created or updated type)from Response Management
    * @throws CTPException something went wrong
    */
   @ServiceActivator(inputChannel = "acceptUACEvent")

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RetryableRespondentDataRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RetryableRespondentDataRepository.java
@@ -56,6 +56,7 @@ public class RetryableRespondentDataRepository {
    *
    * @param uac - object to be stored in the cloud
    * @throws CTPException - if a cloud exception was detected.
+   * @throws DataStoreContentionException - on contention
    */
   @Retryable(
       label = "writeUAC",
@@ -87,6 +88,7 @@ public class RetryableRespondentDataRepository {
    *
    * @param collectionCase - is the case to be stored in the cloud.
    * @throws CTPException - if a cloud exception was detected.
+   * @throws DataStoreContentionException - on contention
    */
   @Retryable(
       label = "writeCollectionCase",

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplIT_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplIT_Test.java
@@ -8,8 +8,8 @@ import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.client.Channel;
-import lombok.SneakyThrows;
 import java.util.Date;
+import lombok.SneakyThrows;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplUnit_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplUnit_Test.java
@@ -3,13 +3,12 @@ package uk.gov.ons.ctp.integration.rhsvc.message.impl;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.test.util.ReflectionTestUtils;
-import uk.gov.ons.ctp.common.error.CTPException;
+import lombok.SneakyThrows;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
 import uk.gov.ons.ctp.common.event.model.Header;
 import uk.gov.ons.ctp.common.event.model.UAC;
@@ -41,7 +40,8 @@ public class UacEventReceiverImplUnit_Test {
     target.setRespondentDataRepo(mockRespondentDataRepo);
   }
 
-  private void prepareAndAcceptEvent(String qid) throws CTPException {
+  @SneakyThrows
+  private void prepareAndAcceptEvent(String qid, EventType type) {
     // Construct UACEvent
     uacEventFixture = new UACEvent();
     UACPayload uacPayloadFixture = uacEventFixture.getPayload();
@@ -49,7 +49,7 @@ public class UacEventReceiverImplUnit_Test {
     uacFixture.setQuestionnaireId(qid);
 
     Header headerFixture = new Header();
-    headerFixture.setType(EventType.UAC_UPDATED);
+    headerFixture.setType(type);
     headerFixture.setTransactionId("c45de4dc-3c3b-11e9-b210-d663bd873d93");
     uacEventFixture.setEvent(headerFixture);
 
@@ -57,48 +57,60 @@ public class UacEventReceiverImplUnit_Test {
     target.acceptUACEvent(uacEventFixture);
   }
 
-  private void acceptUacEvent(String qid) throws CTPException {
-    prepareAndAcceptEvent(qid);
+  @SneakyThrows
+  private void acceptUacEvent(String qid) {
+    acceptUacEvent(qid, EventType.UAC_UPDATED);
+  }
+
+  @SneakyThrows
+  private void acceptUacEvent(String qid, EventType type) {
+    prepareAndAcceptEvent(qid, type);
     verify(mockRespondentDataRepo).writeUAC(uacFixture);
   }
 
-  private void filterUacEvent(String qid) throws CTPException {
-    prepareAndAcceptEvent(qid);
+  @SneakyThrows
+  private void filterUacEvent(String qid) {
+    prepareAndAcceptEvent(qid, EventType.UAC_UPDATED);
     verify(mockRespondentDataRepo, never()).writeUAC(uacFixture);
   }
 
   @Test
-  public void shouldAcceptUacEventPrefix01() throws CTPException {
+  public void shouldAcceptUacEventPrefix01() {
     acceptUacEvent(RespondentHomeFixture.QID_01);
   }
 
   @Test
-  public void shouldAcceptUacEventPrefix21() throws CTPException {
+  public void shouldAcceptUacEventPrefix21() {
     acceptUacEvent(RespondentHomeFixture.QID_21);
   }
 
   @Test
-  public void shouldAcceptUacEventPrefix31() throws CTPException {
+  public void shouldAcceptUacEventPrefix31() {
     acceptUacEvent(RespondentHomeFixture.QID_31);
   }
 
   @Test
-  public void shouldFilterUacEventPrefix11() throws CTPException {
+  public void shouldFilterUacEventPrefix11() {
     filterUacEvent(RespondentHomeFixture.QID_11);
   }
 
   @Test
-  public void shouldFilterUacEventPrefix12() throws CTPException {
+  public void shouldFilterUacEventPrefix12() {
     filterUacEvent(RespondentHomeFixture.QID_12);
   }
 
   @Test
-  public void shouldFilterUacEventPrefix13() throws CTPException {
+  public void shouldFilterUacEventPrefix13() {
     filterUacEvent(RespondentHomeFixture.QID_13);
   }
 
   @Test
-  public void shouldFilterUacEventPrefix14() throws CTPException {
+  public void shouldFilterUacEventPrefix14() {
     filterUacEvent(RespondentHomeFixture.QID_14);
+  }
+
+  @Test
+  public void shouldAcceptUacCreatedEvent() {
+    acceptUacEvent(RespondentHomeFixture.QID_01, EventType.UAC_CREATED);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplUnit_Test.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/message/impl/UacEventReceiverImplUnit_Test.java
@@ -3,12 +3,13 @@ package uk.gov.ons.ctp.integration.rhsvc.message.impl;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.SneakyThrows;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.test.util.ReflectionTestUtils;
-import lombok.SneakyThrows;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
 import uk.gov.ons.ctp.common.event.model.Header;
 import uk.gov.ons.ctp.common.event.model.UAC;


### PR DESCRIPTION
# Motivation and Context
Tests to show that RH service can now accept UAC_CREATED event type and handle in the same way as UAC_UPDATED.

Relies on previously merged CR-871 change in event-publisher.
