### PR TITLE
Cr 875 switch to undertow and set thread counts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,17 +36,11 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-tomcat</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-undertow</artifactId>
+      <artifactId>spring-boot-starter-tomcat</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,17 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-tomcat</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-tomcat</artifactId>
+      <artifactId>spring-boot-starter-undertow</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-jetty</artifactId>
+      <artifactId>spring-boot-starter-undertow</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,8 +81,7 @@ management:
 
 server:
   port: 8071
-  undertow.worker-threads: 200
-  undertow.io-threads: 20
+  tomcat.max-threads: 9
 
 spring:
   mvc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,8 @@ management:
 
 server:
   port: 8071
+  undertow.worker-threads: 200
+  undertow.io-threads: 20
 
 spring:
   mvc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,7 +81,8 @@ management:
 
 server:
   port: 8071
-  tomcat.max-threads: 9
+  undertow.worker-threads: 40
+  undertow.io-threads: 6
 
 spring:
   mvc:


### PR DESCRIPTION
# Motivation and Context
Due to a serious threading bug with Jetty RHSVC has been switched from Jetty to Undertow.
We considered using Tomcat but Undertow was able to service more requests from the same hardware so we went with that.

# What has changed
Pom updated to use undertow, and corresponding Undertow thread configuration added to the application.yml file.

# How to test?
This should be a purely internal change.
