### PR TITLE
CR-929 Added debug logging to reveal crude timings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.28</version>
+      <version>0.0.31</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/CaseEndpoint.java
@@ -49,6 +49,8 @@ public class CaseEndpoint {
           CTPException.Fault.RESOURCE_NOT_FOUND, "Failed to retrieve UPRN: " + uprn.getValue());
     }
 
+    log.with("pathParam.uprn", uprn).debug("Exit GET getHHCaseByUPRN");
+
     return ResponseEntity.ok(results);
   }
 
@@ -77,6 +79,9 @@ public class CaseEndpoint {
     }
 
     CaseDTO result = caseService.modifyAddress(addressChange);
+
+    log.with("pathParam.caseId", caseId).debug("Exit modifyAddress");
+
     return ResponseEntity.ok(result);
   }
 
@@ -107,6 +112,8 @@ public class CaseEndpoint {
       log.with(caseId).warn(message);
       throw new CTPException(Fault.BAD_REQUEST, message);
     }
+
+    log.with("pathParam.caseId", caseId).debug("Exit POST fulfilmentRequestBySMS");
 
     caseService.fulfilmentRequestBySMS(requestBodyDTO);
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/FulfilmentsEndpoint.java
@@ -71,6 +71,10 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
 
     log.with("size", fulfilments.size()).info("Found fulfilment(s)");
 
+    log.with("requestParam.caseType", caseType)
+        .with("requestParam.productGroup", productGroup)
+        .debug("Exit GET getFulfilments");
+
     return ResponseEntity.ok(fulfilments);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/SurveyLaunchedEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/SurveyLaunchedEndpoint.java
@@ -29,6 +29,9 @@ public final class SurveyLaunchedEndpoint {
       throws CTPException {
 
     log.with("requestBody", surveyLaunchedDTO).info("Entering POST surveyLaunched");
+
     surveyLaunchedService.surveyLaunched(surveyLaunchedDTO);
+
+    log.with("caseId", surveyLaunchedDTO.getCaseId()).debug("Exit POST surveyLaunched");
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/UniqueAccessCodeEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/UniqueAccessCodeEndpoint.java
@@ -35,6 +35,8 @@ public class UniqueAccessCodeEndpoint {
     log.info("Entering GET getUACClaimContext");
     UniqueAccessCodeDTO uacDTO = uacService.getAndAuthenticateUAC(uacHash);
 
+    log.debug("Exit GET getUACClaimContext");
+
     return ResponseEntity.ok(uacDTO);
   }
 }


### PR DESCRIPTION
This PR is for the addition of debug logging in the RH service.
It aims to help address the RHSVC scalability problems by providing data on: 
- Total transaction time
- Firestore request times
- Rabbit event publishing times