### PR TITLE
CR-991 update/correct out-of-date spring boot properties

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,10 +81,11 @@ management:
 
 server:
   port: 8071
-  undertow.worker-threads: 40
-  undertow.io-threads: 6
-  shutdown:
-    grace-period: 30s
+  shutdown: graceful
+  undertow:
+    threads:
+      worker: 40
+      io: 6
 
 spring:
   mvc:
@@ -99,6 +100,8 @@ spring:
       enabled: never
   application:
     name: ONS RespondentHomeService
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
 
 rabbitmq:
   username: guest


### PR DESCRIPTION
Some Spring boot properties have gone out of date, as spotted by @philwhiles  .
This updates those properties, in particular the undertow and graceful shutdown properties (which sneakily changed between Spring Boot 2.3.0-RC1 and 2.3.0-RELEASE1).

I have retested graceful shudown in the performance environment and things perform as expected; actually with fewer retries at the RHUI end. So this is an improvement.