### PR TITLE
Cr 1044 form type c

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.61-SNAPSHOT</version>
+      <version>0.0.61</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.60</version>
+      <version>0.0.61-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImpl.java
@@ -50,7 +50,7 @@ public class UniqueAccessCodeServiceImpl implements UniqueAccessCodeService {
 
   // Enums to capture the linking matrix of valid form type and case types.
   // Original table is from:
-  // https://collaborate2.ons.gov.uk/confluence/display/SDC/Auth.05+-+Unlinked+Authentication
+  // https://collaborate2.ons.gov.uk/confluence/display/SDC/RH+-+Authentication+-+Unlinked+UAC
   private enum LinkingCombination {
     H1(FormType.H, CaseType.HH),
     H2(FormType.H, CaseType.SPG),
@@ -58,7 +58,7 @@ public class UniqueAccessCodeServiceImpl implements UniqueAccessCodeService {
     I1(FormType.I, CaseType.HH),
     I2(FormType.I, CaseType.SPG),
     I3(FormType.I, CaseType.CE),
-    C1(FormType.CE1, CaseType.CE);
+    C1(FormType.C, CaseType.CE);
 
     private FormType uacFormType;
     private CaseType caseCaseType;
@@ -308,7 +308,7 @@ public class UniqueAccessCodeServiceImpl implements UniqueAccessCodeService {
 
     // Set address level for case
     if ((caseType == CaseType.CE || caseType == CaseType.SPG)
-        && uac.getFormType().equals(FormType.CE1.name())) {
+        && uac.getFormType().equals(FormType.C.name())) {
       address.setAddressLevel(AddressLevel.E.name());
     } else {
       address.setAddressLevel(AddressLevel.U.name());
@@ -328,7 +328,7 @@ public class UniqueAccessCodeServiceImpl implements UniqueAccessCodeService {
     // linked
     // rather than disallowed. ie we will only link those combinations indicated as LINK:YES in the
     // matrix included in
-    // https://collaborate2.ons.gov.uk/confluence/display/SDC/Auth.05+-+Unlinked+Authentication
+    // https://collaborate2.ons.gov.uk/confluence/display/SDC/RH+-+Authentication+-+Unlinked+UAC
 
     FormType uacFormType = FormType.valueOf(uac.getFormType());
     CaseType caseCaseType = CaseType.valueOf(collectionCase.getCaseType());

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
@@ -594,7 +594,7 @@ public class UniqueAccessCodeServiceImplTest {
    * in the unlinked authentication wiki page.
    *
    * <p>The code is based on the permutations listed in:
-   * https://collaborate2.ons.gov.uk/confluence/display/SDC/Auth.05+-+Unlinked+Authentication#Matrix
+   * https://collaborate2.ons.gov.uk/confluence/display/SDC/RH+-+Authentication+-+Unlinked+UAC
    *
    * @throws CTPException
    */
@@ -611,9 +611,9 @@ public class UniqueAccessCodeServiceImplTest {
     doLinkingTest(FormType.I, CaseType.SPG, LinkingExpectation.OK);
     doLinkingTest(FormType.I, CaseType.CE, LinkingExpectation.OK);
 
-    doLinkingTest(FormType.CE1, CaseType.HH, LinkingExpectation.INVALID);
-    doLinkingTest(FormType.CE1, CaseType.SPG, LinkingExpectation.INVALID);
-    doLinkingTest(FormType.CE1, CaseType.CE, LinkingExpectation.OK);
+    doLinkingTest(FormType.C, CaseType.HH, LinkingExpectation.INVALID);
+    doLinkingTest(FormType.C, CaseType.SPG, LinkingExpectation.INVALID);
+    doLinkingTest(FormType.C, CaseType.CE, LinkingExpectation.OK);
   }
 
   private void doLinkingTest(

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.UAC.unlinkedCE.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.UAC.unlinkedCE.json
@@ -3,6 +3,6 @@
 	"uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
 	"active": true,
 	"questionnaireId": "1110000009",
-	"formType": "CE1"
+	"formType": "C"
 }
 ]


### PR DESCRIPTION
# Motivation and Context
Use FormType "C" instead of "CE1".
Also corrected some javadoc using outdated confluence URL.