### PR TITLE
Cr 696 add webform endpoint

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/WebformEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/WebformEndpoint.java
@@ -1,0 +1,36 @@
+package uk.gov.ons.ctp.integration.rhsvc.endpoint;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import io.micrometer.core.annotation.Timed;
+import java.util.UUID;
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.integration.rhsvc.representation.WebformDTO;
+import uk.gov.ons.ctp.integration.rhsvc.service.WebformService;
+
+/** The REST endpoint controller for the webform endpoint. */
+@Timed
+@RestController
+@RequestMapping(value = "/", produces = "application/json")
+public final class WebformEndpoint {
+
+  private static final Logger log = LoggerFactory.getLogger(WebformEndpoint.class);
+
+  @Autowired private WebformService webformService;
+
+  @RequestMapping(value = "/webform", method = RequestMethod.POST)
+  public void webformCapture(@Valid @RequestBody WebformDTO webformDTO) throws CTPException {
+
+    log.with("requestBody", webformDTO).info("Entering POST webformCapture");
+
+    UUID id = webformService.webformCapture(webformDTO);
+
+    log.with("caseId", id).debug("Exit POST webformCapture");
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/repository/RespondentDataRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/repository/RespondentDataRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
 import uk.gov.ons.ctp.common.event.model.UAC;
+import uk.gov.ons.ctp.integration.rhsvc.representation.WebformPersistedDTO;
 
 /** Repository for Respondent Data */
 public interface RespondentDataRepository {
@@ -11,6 +12,8 @@ public interface RespondentDataRepository {
   void writeUAC(UAC uac) throws CTPException;
 
   void writeCollectionCase(CollectionCase collectionCase) throws CTPException;
+
+  void writeWebform(WebformPersistedDTO webformPersistedDTO) throws CTPException;
 
   Optional<UAC> readUAC(String universalAccessCode) throws CTPException;
 

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RespondentDataRepositoryImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RespondentDataRepositoryImpl.java
@@ -13,6 +13,7 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
 import uk.gov.ons.ctp.common.event.model.UAC;
 import uk.gov.ons.ctp.integration.rhsvc.repository.RespondentDataRepository;
+import uk.gov.ons.ctp.integration.rhsvc.representation.WebformPersistedDTO;
 
 /** A RespondentDataRepository implementation for CRUD operations on Respondent data entities */
 @Service
@@ -28,8 +29,12 @@ public class RespondentDataRepositoryImpl implements RespondentDataRepository {
   @Value("${cloud-storage.uac-schema-name}")
   private String uacSchemaName;
 
+  @Value("${cloud-storage.webform-schema-name}")
+  private String webformSchemaName;
+
   String caseSchema;
   private String uacSchema;
+  private String webformSchema;
 
   private static final String[] SEARCH_BY_UPRN_PATH = new String[] {"address", "uprn"};
 
@@ -37,6 +42,7 @@ public class RespondentDataRepositoryImpl implements RespondentDataRepository {
   public void init() {
     caseSchema = gcpProject + "-" + caseSchemaName.toLowerCase();
     uacSchema = gcpProject + "-" + uacSchemaName.toLowerCase();
+    webformSchema = gcpProject + "-" + webformSchemaName.toLowerCase();
   }
 
   @Autowired
@@ -77,6 +83,18 @@ public class RespondentDataRepositoryImpl implements RespondentDataRepository {
   public void writeCollectionCase(final CollectionCase collectionCase) throws CTPException {
     String id = collectionCase.getId();
     cloudDataStore.storeObject(caseSchema, id, collectionCase, id);
+  }
+
+  /**
+   * Writes webform data into the cloud data store.
+   *
+   * @param webformPersistedDTO - holds the webform data to save in the cloud.
+   * @throws CTPException - if a cloud exception was detected.
+   */
+  @Override
+  public void writeWebform(WebformPersistedDTO webformPersistedDTO) throws CTPException {
+    String id = webformPersistedDTO.getId();
+    cloudDataStore.storeObject(webformSchema, id, webformPersistedDTO, id);
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/WebformDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/WebformDTO.java
@@ -1,0 +1,42 @@
+package uk.gov.ons.ctp.integration.rhsvc.representation;
+
+import java.io.Serializable;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.ons.ctp.common.domain.Region;
+
+/** This object holds details from a webform. */
+@Data
+@NoArgsConstructor
+@SuppressWarnings("serial")
+public class WebformDTO implements Serializable {
+
+  /** enum for category */
+  public enum WebformCategory {
+    MISSING_INFORMATION,
+    TECHNICAL,
+    FORM,
+    COMPLAINT,
+    ADDRESS,
+    OTHER
+  }
+
+  /** enum for language */
+  public enum WebformLanguage {
+    EN,
+    CY
+  }
+
+  @NotNull private WebformCategory category;
+
+  @NotNull private Region region;
+
+  @NotNull private WebformLanguage language;
+
+  @NotNull private String name; // PMB Length ?
+
+  @NotNull private String description; // PMB Length ?
+
+  @NotNull private String email;
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/WebformDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/WebformDTO.java
@@ -34,9 +34,9 @@ public class WebformDTO implements Serializable {
 
   @NotNull private WebformLanguage language;
 
-  @NotNull private String name; // PMB Length ?
+  @NotNull private String name;
 
-  @NotNull private String description; // PMB Length ?
+  @NotNull private String description;
 
   @NotNull private String email;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/WebformDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/WebformDTO.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.ctp.integration.rhsvc.representation;
 
-import java.io.Serializable;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,8 +8,7 @@ import uk.gov.ons.ctp.common.domain.Region;
 /** This object holds details from a webform. */
 @Data
 @NoArgsConstructor
-@SuppressWarnings("serial")
-public class WebformDTO implements Serializable {
+public class WebformDTO {
 
   /** enum for category */
   public enum WebformCategory {

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/WebformPersistedDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/WebformPersistedDTO.java
@@ -1,21 +1,16 @@
 package uk.gov.ons.ctp.integration.rhsvc.representation;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.io.Serializable;
 import java.util.Date;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.gov.ons.ctp.common.jackson.CustomDateSerialiser;
 
 /** This object holds webform data with extra details for the datastore. */
 @Data
 @NoArgsConstructor
-@SuppressWarnings("serial")
-public class WebformPersistedDTO implements Serializable {
+public class WebformPersistedDTO {
 
   private String id;
 
-  @JsonSerialize(using = CustomDateSerialiser.class)
   private Date createdDateTime;
 
   private WebformDTO webformData;

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/WebformPersistedDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/WebformPersistedDTO.java
@@ -1,0 +1,22 @@
+package uk.gov.ons.ctp.integration.rhsvc.representation;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.Serializable;
+import java.util.Date;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.ons.ctp.common.jackson.CustomDateSerialiser;
+
+/** This object holds webform data with extra details for the datastore. */
+@Data
+@NoArgsConstructor
+@SuppressWarnings("serial")
+public class WebformPersistedDTO implements Serializable {
+
+  private String id;
+
+  @JsonSerialize(using = CustomDateSerialiser.class)
+  private Date createdDateTime;
+
+  private WebformDTO webformData;
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/WebformService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/WebformService.java
@@ -1,0 +1,11 @@
+package uk.gov.ons.ctp.integration.rhsvc.service;
+
+import java.util.UUID;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.integration.rhsvc.representation.WebformDTO;
+
+/** Service responsible for Webform requests */
+public interface WebformService {
+
+  public UUID webformCapture(WebformDTO webformDTO) throws CTPException;
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/WebformServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/WebformServiceImpl.java
@@ -1,0 +1,42 @@
+package uk.gov.ons.ctp.integration.rhsvc.service.impl;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import java.util.Date;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.integration.rhsvc.repository.RespondentDataRepository;
+import uk.gov.ons.ctp.integration.rhsvc.representation.WebformDTO;
+import uk.gov.ons.ctp.integration.rhsvc.representation.WebformPersistedDTO;
+import uk.gov.ons.ctp.integration.rhsvc.service.WebformService;
+
+/**
+ * This is a service layer class, which performs RH business level logic for the webform endpoint.
+ */
+@Service
+public class WebformServiceImpl implements WebformService {
+  private static final Logger log = LoggerFactory.getLogger(WebformServiceImpl.class);
+
+  @Autowired private RespondentDataRepository dataRepo;
+
+  @Override
+  public UUID webformCapture(WebformDTO webformDTO) throws CTPException {
+
+    UUID id = UUID.randomUUID();
+
+    log.with("id", id).with("webformDTO", webformDTO).info("Capturing webform data");
+
+    WebformPersistedDTO webformPersistedDTO = new WebformPersistedDTO();
+    webformPersistedDTO.setId(id.toString());
+    webformPersistedDTO.setCreatedDateTime(new Date());
+    webformPersistedDTO.setWebformData(webformDTO);
+
+    dataRepo.writeWebform(webformPersistedDTO);
+
+    log.with("id", id).with("webformDTO", webformDTO).info("Completed capture of webform data");
+
+    return id;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,6 +111,7 @@ swagger-settings:
 cloud-storage:
   case-schema-name: case
   uac-schema-name: uac
+  webform-schema-name: webform
   event-backup-schema-name: event-backup
   backoff:
     initial: 100

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/WebformEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/WebformEndpointTest.java
@@ -1,0 +1,143 @@
+package uk.gov.ons.ctp.integration.rhsvc.endpoint;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.ons.ctp.common.MvcHelper.postJson;
+import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.gov.ons.ctp.common.FixtureHelper;
+import uk.gov.ons.ctp.common.error.RestExceptionHandler;
+import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
+import uk.gov.ons.ctp.integration.rhsvc.representation.WebformDTO;
+import uk.gov.ons.ctp.integration.rhsvc.service.WebformService;
+
+/** Respondent Home Endpoint Unit tests */
+@RunWith(MockitoJUnitRunner.class)
+public final class WebformEndpointTest {
+  @InjectMocks private WebformEndpoint webformEndpoint;
+
+  @Mock WebformService webformService;
+
+  private MockMvc mockMvc;
+  private ObjectMapper mapper = new ObjectMapper();
+
+  private static final UUID TEST_UUID = UUID.fromString("fdc64299-1a08-49b1-af33-63b322a04e34");
+
+  private WebformDTO webformRequest;
+  private String webformRequestJson;
+
+  /**
+   * Set up of tests
+   *
+   * @throws Exception exception thrown
+   */
+  @Before
+  public void setUp() throws Exception {
+    this.mockMvc =
+        MockMvcBuilders.standaloneSetup(webformEndpoint)
+            .setHandlerExceptionResolvers(mockAdviceFor(RestExceptionHandler.class))
+            .setMessageConverters(new MappingJackson2HttpMessageConverter(new CustomObjectMapper()))
+            .build();
+
+    webformRequest = FixtureHelper.loadClassFixtures(WebformDTO[].class).get(0);
+    webformRequestJson = mapper.writeValueAsString(webformRequest);
+  }
+
+  @Test
+  public void webform_validRequest() throws Exception {
+    Mockito.when(webformService.webformCapture(any()))
+        .thenReturn(UUID.fromString(TEST_UUID.toString()));
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/webform")
+                .content(mapper.writeValueAsString(webformRequest))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  public void webform_nullCategory() throws Exception {
+    webformRequest.setCategory(null);
+    invokeEndpointAndExpectBadRequest(webformRequest);
+  }
+
+  @Test
+  public void webform_unknownCategory() throws Exception {
+    webformRequestJson = updateJson(webformRequestJson, "category", "foo");
+    invokeEndpointAndExpectBadRequest(webformRequestJson);
+  }
+
+  @Test
+  public void webform_nullRegion() throws Exception {
+    webformRequest.setRegion(null);
+    invokeEndpointAndExpectBadRequest(webformRequest);
+  }
+
+  @Test
+  public void webform_unknownRegion() throws Exception {
+    webformRequestJson = updateJson(webformRequestJson, "region", "foo");
+    invokeEndpointAndExpectBadRequest(webformRequestJson);
+  }
+
+  @Test
+  public void webform_nullLanguage() throws Exception {
+    webformRequest.setLanguage(null);
+    invokeEndpointAndExpectBadRequest(webformRequest);
+  }
+
+  @Test
+  public void webform_unknownLanguage() throws Exception {
+    webformRequestJson = updateJson(webformRequestJson, "language", "foo");
+    invokeEndpointAndExpectBadRequest(webformRequestJson);
+  }
+
+  @Test
+  public void webform_nullName() throws Exception {
+    webformRequest.setName(null);
+    invokeEndpointAndExpectBadRequest(webformRequest);
+  }
+
+  @Test
+  public void webform_nullDescription() throws Exception {
+    webformRequest.setDescription(null);
+    invokeEndpointAndExpectBadRequest(webformRequest);
+  }
+
+  @Test
+  public void webform_nullEmail() throws Exception {
+    webformRequest.setEmail(null);
+    invokeEndpointAndExpectBadRequest(webformRequest);
+  }
+
+  private void invokeEndpointAndExpectBadRequest(WebformDTO webformRequest)
+      throws Exception, JsonProcessingException {
+    String webformAsJson = mapper.writeValueAsString(webformRequest);
+    invokeEndpointAndExpectBadRequest(webformAsJson);
+  }
+
+  private void invokeEndpointAndExpectBadRequest(String webformRequestJson) throws Exception {
+    mockMvc.perform(postJson("/webform", webformRequestJson)).andExpect(status().isBadRequest());
+  }
+
+  private String updateJson(String webformRequestJson, String fieldName, String newValue) {
+    String regex = fieldName + ".*?,";
+    String replacement = fieldName + "\":\"" + newValue + "\",";
+    return webformRequestJson.replaceFirst(regex, replacement);
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/WebformServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/WebformServiceImplTest.java
@@ -36,7 +36,7 @@ public class WebformServiceImplTest {
     webformService.webformCapture(webformDTO);
     long timestampAfter = System.currentTimeMillis();
 
-    // Get hold of the event pay load that surveyLaunchedService created
+    // Get hold of the webform data written to the repo
     Mockito.verify(dataRepo).writeWebform(webformPersistedCaptor.capture());
     WebformPersistedDTO webformPersisted = webformPersistedCaptor.getValue();
 

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/WebformServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/WebformServiceImplTest.java
@@ -1,0 +1,55 @@
+package uk.gov.ons.ctp.integration.rhsvc.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ons.ctp.common.FixtureHelper;
+import uk.gov.ons.ctp.integration.rhsvc.repository.RespondentDataRepository;
+import uk.gov.ons.ctp.integration.rhsvc.representation.WebformDTO;
+import uk.gov.ons.ctp.integration.rhsvc.representation.WebformPersistedDTO;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WebformServiceImplTest {
+
+  @Mock private RespondentDataRepository dataRepo;
+
+  @InjectMocks WebformServiceImpl webformService;
+
+  @Captor ArgumentCaptor<WebformPersistedDTO> webformPersistedCaptor;
+
+  @Test
+  public void webformCapture() throws Exception {
+    WebformDTO webformDTO = FixtureHelper.loadClassFixtures(WebformDTO[].class).get(0);
+
+    // Send in the webform
+    long timestampBefore = System.currentTimeMillis();
+    webformService.webformCapture(webformDTO);
+    long timestampAfter = System.currentTimeMillis();
+
+    // Get hold of the event pay load that surveyLaunchedService created
+    Mockito.verify(dataRepo).writeWebform(webformPersistedCaptor.capture());
+    WebformPersistedDTO webformPersisted = webformPersistedCaptor.getValue();
+
+    // Verify that id really is a uuid
+    assertNotNull(webformPersisted.getId(), UUID.fromString(webformPersisted.getId()));
+
+    // Check created timestamp looks correct
+    long createdTimestamp = webformPersisted.getCreatedDateTime().getTime();
+    String timestampDetails =
+        "Before: " + createdTimestamp + " After: " + timestampAfter + " DTO: " + createdTimestamp;
+    assertTrue(timestampDetails, createdTimestamp >= timestampBefore);
+    assertTrue(timestampDetails, createdTimestamp <= timestampAfter);
+
+    assertEquals(webformDTO, webformPersisted.getWebformData());
+  }
+}

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/endpoint/WebformEndpointTest.WebformDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/endpoint/WebformEndpointTest.WebformDTO.json
@@ -1,0 +1,8 @@
+{
+  "category": "COMPLAINT",
+  "region": "E",
+  "language": "EN", 
+  "name": "Bill Bloggs",
+  "description": "Computer says no",
+  "email": "bb@yahoo.co.uk"
+}

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/WebformServiceImplTest.WebformDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/WebformServiceImplTest.WebformDTO.json
@@ -1,0 +1,8 @@
+{
+  "category": "COMPLAINT",
+  "region": "E",
+  "language": "EN", 
+  "name": "Bill Bloggs",
+  "description": "Computer says no",
+  "email": "bb@yahoo.co.uk"
+}


### PR DESCRIPTION
This change adds a new endpoint of '/webform' which saves data into a new Firestore collection. 
A subsequent CR will read from the collection and send out an email.