### PR TITLE
Cr 1065 play firestore events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.40</version>
+      <version>0.0.43-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.43-CR1065-SNAPSHOT</version>
+      <version>0.0.43</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.43-SNAPSHOT</version>
+      <version>0.0.43-CR1065-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,6 @@
       <scope>test</scope>
     </dependency>
 
-
   </dependencies>
 
   <build>

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
@@ -285,7 +285,6 @@ public class CaseServiceImpl implements CaseService {
     fulfilmentRequest.setFulfilmentCode(fulfilmentCode);
     fulfilmentRequest.setCaseId(caseId.toString());
     fulfilmentRequest.setContact(contact);
-    fulfilmentRequest.setAddress(caseDetails.getAddress());
     return fulfilmentRequest;
   }
 


### PR DESCRIPTION
Just a pom update, (and also removed a line to fit in with the latest FulfilmentRequest model object, which removed the address element many weeks ago for another JIRA).

Ensure the latest version of event publisher is used, so there is no chance that out-of-date event structures are stored in firestore.
