### PR TITLE
CR-1208 | Pointing to the new release version of census-int-common-service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.65</version>
+      <version>0.0.66</version>
     </dependency>
 
     <dependency>

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplTest.java
@@ -326,7 +326,7 @@ public class CaseServiceImplTest {
 
   @Test
   public void createNewCase_CE() throws Exception {
-    doCreateNewCaseTest(EstabType.HOLIDAY_PARK, AddressType.CE, CaseType.CE, AddressLevel.E);
+    doCreateNewCaseTest(EstabType.CARE_HOME, AddressType.CE, CaseType.CE, AddressLevel.E);
   }
 
   @Test


### PR DESCRIPTION
The EstabType has been update in census-int-common-service. A new version of census-int-common-service has been released which is 0.0.66. Updating pom.xml to point to this new version.

Also some tests have been updated as they were using the EstabTypes which do not exist anymore after the update to the EstabType enum.

For more details on the changes in census-int-common-service please have a look at https://collaborate2.ons.gov.uk/jira/browse/CR-1208.
