### PR TITLE
CR-1247 modify cloud logback config so it doesn't omit log entries

### DIFF
--- a/src/main/resources/application-testing.yml
+++ b/src/main/resources/application-testing.yml
@@ -1,0 +1,6 @@
+logging:
+  level:
+    uk.gov.ons.ctp: DEBUG
+    org.springframework: WARN
+  profile: CLOUD
+  useJson: true

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -61,14 +61,8 @@
         <nestedField>
           <fieldName>data</fieldName>
           <providers>
-            <arguments>
-              <includeNonStructuredArguments>true
-              </includeNonStructuredArguments>
-              <nonStructuredArgumentsFieldPrefix>prefix
-              </nonStructuredArgumentsFieldPrefix>
-            </arguments>
-        <tags />
-        <logstashMarkers />
+            <tags />
+            <logstashMarkers />
           </providers>
         </nestedField>
       </providers>


### PR DESCRIPTION
Stop the CLOUD logback configuration from omitting logging entries, particularly from the firestore retry logic.