### PR TITLE
CR-1240 | Fixing the  missing address level bug

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
@@ -9,7 +9,6 @@ import ma.glasnost.orika.MapperFacade;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import uk.gov.ons.ctp.common.domain.AddressLevel;
 import uk.gov.ons.ctp.common.domain.CaseType;
 import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -84,9 +83,6 @@ public class CaseServiceImpl implements CaseService {
       log.with("caseId", newCase.getId())
           .with("primaryCaseType", caseType)
           .debug("Created new case");
-      String addressLevel =
-          caseType.equals(CaseType.CE) ? AddressLevel.E.name() : AddressLevel.U.name();
-      newCase.getAddress().setAddressLevel(addressLevel);
 
       // Store new case in Firestore
       dataRepo.writeCollectionCase(newCase);

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
@@ -84,8 +84,8 @@ public class CaseServiceImpl implements CaseService {
       log.with("caseId", newCase.getId())
           .with("primaryCaseType", caseType)
           .debug("Created new case");
-      String addressLevel = caseType.equals(CaseType.CE)
-              ? AddressLevel.E.name() : AddressLevel.U.name();
+      String addressLevel =
+          caseType.equals(CaseType.CE) ? AddressLevel.E.name() : AddressLevel.U.name();
       newCase.getAddress().setAddressLevel(addressLevel);
 
       // Store new case in Firestore

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
@@ -84,6 +84,9 @@ public class CaseServiceImpl implements CaseService {
       log.with("caseId", newCase.getId())
           .with("primaryCaseType", caseType)
           .debug("Created new case");
+      String addressLevel = caseType.equals(CaseType.CE)
+              ? AddressLevel.E.name() : AddressLevel.U.name();
+      newCase.getAddress().setAddressLevel(addressLevel);
 
       // Store new case in Firestore
       dataRepo.writeCollectionCase(newCase);
@@ -92,13 +95,6 @@ public class CaseServiceImpl implements CaseService {
       ServiceUtil.sendNewAddressEvent(eventPublisher, newCase);
 
       caseToReturn = mapperFacade.map(newCase, CaseDTO.class);
-    }
-
-    // Set address level for case
-    if (caseToReturn.getCaseType().equals(CaseType.CE.name())) {
-      caseToReturn.setAddressLevel(AddressLevel.E.name());
-    } else {
-      caseToReturn.setAddressLevel(AddressLevel.U.name());
     }
 
     return caseToReturn;

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/ServiceUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/ServiceUtil.java
@@ -5,6 +5,7 @@ import com.godaddy.logging.LoggerFactory;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.experimental.UtilityClass;
+import uk.gov.ons.ctp.common.domain.AddressLevel;
 import uk.gov.ons.ctp.common.domain.AddressType;
 import uk.gov.ons.ctp.common.domain.CaseType;
 import uk.gov.ons.ctp.common.domain.EstabType;
@@ -68,6 +69,8 @@ public class ServiceUtil {
     address.setUprn(Long.toString(request.getUprn().getValue()));
     address.setAddressType(caseType.name());
     address.setEstabType(request.getEstabType());
+    address.setAddressLevel(
+        caseType.equals(CaseType.CE) ? AddressLevel.E.name() : AddressLevel.U.name());
     newCase.setAddress(address);
 
     return newCase;

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplTest.java
@@ -316,8 +316,7 @@ public class CaseServiceImplTest {
     CaseDTO newCase = caseSvc.createNewCase(request);
 
     // Verify that returned case holds details for the pre-existing case
-    AddressLevel expectedAddressLevel = AddressLevel.U;
-    testUtil.validateCaseDTO(existingCase, expectedAddressLevel, newCase);
+    testUtil.validateCaseDTO(existingCase, newCase);
 
     // Verify nothing written to Firestore and no events sent
     verify(dataRepo, times(0)).writeCollectionCase(any());
@@ -354,9 +353,10 @@ public class CaseServiceImplTest {
     CaseDTO newCase = caseSvc.createNewCase(request);
 
     Address expectedAddress = mapperFacade.map(request, Address.class);
+    expectedAddress.setAddressLevel(expectedAddressLevel.name());
 
     // Verify returned case
-    testUtil.validateCaseDTO(expectedCaseType, expectedAddress, expectedAddressLevel, newCase);
+    testUtil.validateCaseDTO(expectedCaseType, expectedAddress, newCase);
 
     testUtil.verifyCollectionCaseSavedToFirestore(expectedCaseType, expectedAddress);
 

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/TestUtil.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/TestUtil.java
@@ -42,7 +42,6 @@ public class TestUtil {
   void validateCaseDTO(
       CaseType expectedCaseType,
       Address expectedAddress,
-      AddressLevel expectedAddressLevel,
       CaseDTO actualCase) {
     CollectionCase expectedCollectionCase = new CollectionCase();
     expectedCollectionCase.setId(actualCase.getCaseId().toString());
@@ -50,18 +49,18 @@ public class TestUtil {
     expectedCollectionCase.setCaseType(expectedCaseType.name());
     expectedCollectionCase.setAddress(expectedAddress);
 
-    validateCaseDTO(expectedCollectionCase, expectedAddressLevel, actualCase);
+    validateCaseDTO(expectedCollectionCase, actualCase);
   }
 
   void validateCaseDTO(
-      CollectionCase expectedCase, AddressLevel expectedAddressLevel, CaseDTO actualCase) {
+      CollectionCase expectedCase, CaseDTO actualCase) {
     assertEquals(expectedCase.getId(), actualCase.getCaseId().toString());
     assertEquals(expectedCase.getCaseType(), actualCase.getCaseType());
     assertEquals(expectedCase.getAddress().getAddressType(), actualCase.getAddressType());
     validateAddressDTO(expectedCase.getAddress(), actualCase.getAddress());
     assertEquals(expectedCase.getAddress().getAddressType(), actualCase.getAddressType());
     assertEquals(expectedCase.getAddress().getRegion(), actualCase.getRegion());
-    assertEquals(expectedAddressLevel.toString(), actualCase.getAddressLevel());
+    assertEquals(expectedCase.getAddress().getAddressLevel(), actualCase.getAddressLevel());
     assertEquals(expectedCase.getId(), actualCase.getCaseId().toString());
   }
 

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/TestUtil.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/TestUtil.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 
 import java.util.UUID;
 import org.mockito.ArgumentCaptor;
-import uk.gov.ons.ctp.common.domain.AddressLevel;
 import uk.gov.ons.ctp.common.domain.CaseType;
 import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -39,10 +38,7 @@ public class TestUtil {
     this.eventPublisher = eventPublisher;
   }
 
-  void validateCaseDTO(
-      CaseType expectedCaseType,
-      Address expectedAddress,
-      CaseDTO actualCase) {
+  void validateCaseDTO(CaseType expectedCaseType, Address expectedAddress, CaseDTO actualCase) {
     CollectionCase expectedCollectionCase = new CollectionCase();
     expectedCollectionCase.setId(actualCase.getCaseId().toString());
     expectedCollectionCase.setCollectionExerciseId(COLLECTION_EXERCISE_ID);
@@ -52,8 +48,7 @@ public class TestUtil {
     validateCaseDTO(expectedCollectionCase, actualCase);
   }
 
-  void validateCaseDTO(
-      CollectionCase expectedCase, CaseDTO actualCase) {
+  void validateCaseDTO(CollectionCase expectedCase, CaseDTO actualCase) {
     assertEquals(expectedCase.getId(), actualCase.getCaseId().toString());
     assertEquals(expectedCase.getCaseType(), actualCase.getCaseType());
     assertEquals(expectedCase.getAddress().getAddressType(), actualCase.getAddressType());


### PR DESCRIPTION
The address level for the new cases within in the CaseServiceImpl was set after the case was sent to RM and Firestore which was causing this issue.
The bug has been fixed and the unit tests have been updated accordingly.

Please see https://collaborate2.ons.gov.uk/jira/browse/CR-1240 for more details