### PR TITLE
CR-1330 Using latest rate limiter client and allowing a null/blank cl…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>census-int-rate-limiter-client</artifactId>
-      <version>0.0.5</version>
+      <version>0.0.6</version>
     </dependency>
 
     <!-- ONS END -->

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/CaseEndpoint.java
@@ -126,6 +126,12 @@ public class CaseEndpoint {
         .with("requestBody", requestBodyDTO)
         .info("Entering POST {}", methodName);
 
+    // Treat an empty clientIP as if it's a null value
+    String clientIP = requestBodyDTO.getClientIP();
+    if (clientIP != null && clientIP.isBlank()) {
+      requestBodyDTO.setClientIP(null);
+    }
+
     validateMatchingCaseId(caseId, requestBodyDTO.getCaseId(), methodName);
     caseService.fulfilmentRequestBySMS(requestBodyDTO);
     log.with("pathParam.caseId", caseId).debug("Exit POST {}", methodName);
@@ -139,6 +145,12 @@ public class CaseEndpoint {
       throws CTPException {
     String methodName = "fulfilmentRequestByPost";
     log.with("pathParam.caseId", caseId).info("Entering POST {}", methodName);
+
+    // Treat an empty clientIP as if it's a null value
+    String clientIP = requestBodyDTO.getClientIP();
+    if (clientIP != null && clientIP.isBlank()) {
+      requestBodyDTO.setClientIP(null);
+    }
 
     validateMatchingCaseId(caseId, requestBodyDTO.getCaseId(), methodName);
     caseService.fulfilmentRequestByPost(requestBodyDTO);

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/FulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/FulfilmentRequestDTO.java
@@ -18,9 +18,9 @@ public abstract class FulfilmentRequestDTO {
 
   @NotNull private UUID caseId;
 
-  @NotNull @NotEmpty private List<@NotNull @NotEmpty String> fulfilmentCodes;
+  @NotEmpty private List<@NotEmpty String> fulfilmentCodes;
 
   @NotNull private Date dateTime;
 
-  @NotNull @NotEmpty private String clientIP;
+  private String clientIP;
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/CaseEndpointUnitTest.java
@@ -323,8 +323,44 @@ public class CaseEndpointUnitTest {
   }
 
   @Test
+  public void shouldFulfilByPostWithNullClientIP() throws Exception {
+    ObjectNode json = getPostFulfilmentFixture();
+    json.putNull("clientIP");
+    String url = "/cases/" + json.get("caseId").asText() + "/fulfilments/post";
+    mockMvc.perform(postJson(url, json.toString())).andExpect(status().isOk());
+    verify(caseService).fulfilmentRequestByPost(any(PostalFulfilmentRequestDTO.class));
+  }
+
+  @Test
+  public void shouldFulfilByPostWithEmptyClientIP() throws Exception {
+    ObjectNode json = getPostFulfilmentFixture();
+    json.put("clientIP", "");
+    String url = "/cases/" + json.get("caseId").asText() + "/fulfilments/post";
+    mockMvc.perform(postJson(url, json.toString())).andExpect(status().isOk());
+    verify(caseService).fulfilmentRequestByPost(any(PostalFulfilmentRequestDTO.class));
+  }
+
+  @Test
   public void shouldFulfilBySms() throws Exception {
     ObjectNode json = getSmsFulfilmentFixture();
+    String url = "/cases/" + json.get("caseId").asText() + "/fulfilments/sms";
+    mockMvc.perform(postJson(url, json.toString())).andExpect(status().isOk());
+    verify(caseService).fulfilmentRequestBySMS(any(SMSFulfilmentRequestDTO.class));
+  }
+
+  @Test
+  public void shouldFulfilBySmsWithNullClientIP() throws Exception {
+    ObjectNode json = getSmsFulfilmentFixture();
+    json.putNull("clientIP");
+    String url = "/cases/" + json.get("caseId").asText() + "/fulfilments/sms";
+    mockMvc.perform(postJson(url, json.toString())).andExpect(status().isOk());
+    verify(caseService).fulfilmentRequestBySMS(any(SMSFulfilmentRequestDTO.class));
+  }
+
+  @Test
+  public void shouldFulfilBySmsWithEmptyClientIP() throws Exception {
+    ObjectNode json = getSmsFulfilmentFixture();
+    json.put("clientIP", "");
     String url = "/cases/" + json.get("caseId").asText() + "/fulfilments/sms";
     mockMvc.perform(postJson(url, json.toString())).andExpect(status().isOk());
     verify(caseService).fulfilmentRequestBySMS(any(SMSFulfilmentRequestDTO.class));
@@ -391,22 +427,6 @@ public class CaseEndpointUnitTest {
     json.putArray("fulfilmentCodes").add("A").add("B").add(StringUtils.repeat("C", 12));
     mockMvc.perform(postJson(url, json.toString())).andExpect(status().isOk());
     verify(caseService).fulfilmentRequestByPost(any(PostalFulfilmentRequestDTO.class));
-  }
-
-  @Test
-  public void shouldRejectFulfilByPostWithMissingClientIp() throws Exception {
-    ObjectNode json = getPostFulfilmentFixture();
-    String url = "/cases/" + json.get("caseId").asText() + "/fulfilments/post";
-    json.remove("clientIP");
-    verifyRejectedPostFulfilmentRequest(json, url);
-  }
-
-  @Test
-  public void shouldRejectFulfilByPostWithEmptyClientIp() throws Exception {
-    ObjectNode json = getPostFulfilmentFixture();
-    String url = "/cases/" + json.get("caseId").asText() + "/fulfilments/post";
-    json.put("clientIP", "");
-    verifyRejectedPostFulfilmentRequest(json, url);
   }
 
   @Test
@@ -487,22 +507,6 @@ public class CaseEndpointUnitTest {
     json.putArray("fulfilmentCodes").add("A").add("B").add(StringUtils.repeat("C", 12));
     mockMvc.perform(postJson(url, json.toString())).andExpect(status().isOk());
     verify(caseService).fulfilmentRequestBySMS(any(SMSFulfilmentRequestDTO.class));
-  }
-
-  @Test
-  public void shouldRejectFulfilBySmsWithMissingClientIp() throws Exception {
-    ObjectNode json = getSmsFulfilmentFixture();
-    String url = "/cases/" + json.get("caseId").asText() + "/fulfilments/sms";
-    json.remove("clientIP");
-    verifyRejectedSmsFulfilmentRequest(json, url);
-  }
-
-  @Test
-  public void shouldRejectFulfilBySmsWithEmptyClientIp() throws Exception {
-    ObjectNode json = getSmsFulfilmentFixture();
-    String url = "/cases/" + json.get("caseId").asText() + "/fulfilments/sms";
-    json.put("clientIP", "");
-    verifyRejectedSmsFulfilmentRequest(json, url);
   }
 
   @Test


### PR DESCRIPTION
…ientIP address

Changes:

- Updated pom to use the latest rate limiter client
- Allow RHUI to specify a null or blank clientIP in a fulfilment request
- Fulfilment endpoint maps a blank clientIP to be a null. There is no javax annotation which will accept a null value but reject a blank so RHSvc needs to handle it.
- Updated unit tests
