### PR TITLE
Cr 1365 tolerate rate limiter failure

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcApplication.java
@@ -100,6 +100,12 @@ public class RHSvcApplication {
   }
 
   @Bean
+  public CircuitBreaker rateLimiterCircuitBreaker(
+      Resilience4JCircuitBreakerFactory circuitBreakerFactory) {
+    return circuitBreakerFactory.create("rateLimiterCircuitBreaker");
+  }
+
+  @Bean
   public Customizer<Resilience4JCircuitBreakerFactory> defaultCircuitBreakerCustomiser() {
     CustomCircuitBreakerConfig config = appConfig.getCircuitBreaker();
     log.info("Circuit breaker configuration: {}", config);

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
@@ -281,7 +281,7 @@ public class CaseServiceImpl implements CaseService {
             rateLimiterClient.checkRateLimit(
                 Domain.RH, product, caseType, ipAddress, uprn, contact.getTelNo());
           } catch (CTPException e) {
-            log.error(e, "Rate limiter failure: {}", e.getMessage());
+            log.with("error", e.getMessage()).error(e, "Rate limiter failure");
             // OK to carry on, since it is better to tolerate limiter error than fail operation.
           }
           return null;

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
@@ -294,9 +294,13 @@ public class CaseServiceImpl implements CaseService {
               }
             },
             throwable -> {
-              // OK to carry on, since it is better to tolerate limiter error than fail operation,
-              // however by getting here, the circuit-breaker has counted the failure, or we are
-              // in circuit-breaker OPEN state.
+              // This is the Function for the circuitBreaker.run second parameter, which is called
+              // when an exception is thrown from the first Supplier parameter (above), including
+              // as part of the processing of being in the circuit-breaker OPEN state.
+              //
+              // It is OK to carry on, since it is better to tolerate limiter error than fail
+              // operation, however by getting here, the circuit-breaker has counted the failure,
+              // or we are in circuit-breaker OPEN state.
               if (throwable instanceof CallNotPermittedException) {
                 log.info("Circuit breaker is OPEN calling rate limiter");
               } else {

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplFulfilmentTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplFulfilmentTest.java
@@ -558,6 +558,16 @@ public class CaseServiceImplFulfilmentTest {
     assertNull(eventPayload.getIndividualCaseId());
   }
 
+  @Test
+  public void shouldFulfilRequestBySmsForHousehold_withUnexpectedFailingRateLimiter()
+      throws Exception {
+    mockCircuitBreakerFail();
+    when(rateLimiterClient.checkRateLimit(any(), any(), any(), any(), any(), any()))
+        .thenThrow(new RuntimeException("Unexpected"));
+    FulfilmentRequest eventPayload = doFulfilmentRequestBySMS(Product.CaseType.HH, false);
+    assertNull(eventPayload.getIndividualCaseId());
+  }
+
   // --- helpers
 
   private void verifyRateLimiterCall(


### PR DESCRIPTION
# Motivation and Context
The envoy-rate-limiter provides value-add functionality, however it is more important to function normally if the rate-limiter service has a problem than to fail the normal business function (which it does at present). This PR makes RHSvc tolerate a failing rate-limiter process.

# What has changed
- A circuit-breaker is added around the call to the rate-limiter client
- Any exception other than caused by an HTTP 429 is logged , but ignored
- RH Cucumber tests will now still operate successfully if the rate-limiter is not operational

# How to test?
- unit tests added to cover the functionality
- run RH cucumber with and without rate-limiter present - they work either way
- ensure error logging correctly recorded when rate-limiter not responding

