### PR TITLE
Suggested robust Rabbit transaction handling

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcApplication.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import javax.annotation.PostConstruct;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.transaction.RabbitTransactionManager;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +32,7 @@ import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
 import uk.gov.ons.ctp.common.config.CustomCircuitBreakerConfig;
 import uk.gov.ons.ctp.common.event.EventPublisher;
 import uk.gov.ons.ctp.common.event.EventSender;
@@ -97,6 +99,11 @@ public class RHSvcApplication {
     template.setExchange("events");
     template.setChannelTransacted(true);
     return template;
+  }
+
+  @Bean
+  PlatformTransactionManager transactionManager(ConnectionFactory connectionFactory) {
+    return new RabbitTransactionManager(connectionFactory);
   }
 
   @Bean

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/event/impl/CaseEventReceiverImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/event/impl/CaseEventReceiverImpl.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.model.CaseEvent;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
@@ -34,6 +35,7 @@ public class CaseEventReceiverImpl implements CaseEventReceiver {
    * @param caseEvent CaseEvent message from Response Management
    * @throws CTPException something went wrong
    */
+  @Transactional
   @ServiceActivator(inputChannel = "acceptCaseEvent")
   public void acceptCaseEvent(CaseEvent caseEvent) throws CTPException {
 

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/event/impl/UACEventReceiverImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/event/impl/UACEventReceiverImpl.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.model.UAC;
 import uk.gov.ons.ctp.common.event.model.UACEvent;
@@ -37,6 +38,7 @@ public class UACEventReceiverImpl {
    * @param uacEvent UACEvent message (either created or updated type)from Response Management
    * @throws CTPException something went wrong
    */
+  @Transactional
   @ServiceActivator(inputChannel = "acceptUACEvent")
   public void acceptUACEvent(UACEvent uacEvent) throws CTPException {
 


### PR DESCRIPTION
# Motivation and Context
Evidence from extensive testing in a test harness, that dealing with Rabbit messages without a Rabbit Transaction Manager, or other JTA compatible transaction manager, will result in unpredictable behaviour - loss of messages and/or double-processing.

# What has changed
Introduced Rabbit Transaction Manager and made methods responsible for receiving Rabbit messages transactional, to guarantee that the ACK is only done in the event of success.

# How to test?
It's hard.

# Links
Trello: nope, not yet