### PR TITLE
CR-1332 Restrict linking of HH UAC to CE address

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImpl.java
@@ -44,10 +44,10 @@ public class UniqueAccessCodeServiceImpl implements UniqueAccessCodeService {
   // Enums to capture the linking matrix of valid form type and case types.
   // Original table is from:
   // https://collaborate2.ons.gov.uk/confluence/display/SDC/RH+-+Authentication+-+Unlinked+UAC
+  // https://collaborate2.ons.gov.uk/confluence/display/SDC/Business+Rules
   private enum LinkingCombination {
     H1(FormType.H, CaseType.HH),
     H2(FormType.H, CaseType.SPG),
-    H3(FormType.H, CaseType.CE),
     I1(FormType.I, CaseType.HH),
     I2(FormType.I, CaseType.SPG),
     I3(FormType.I, CaseType.CE),

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
@@ -546,6 +546,7 @@ public class UniqueAccessCodeServiceImplTest {
    *
    * <p>The code is based on the permutations listed in:
    * https://collaborate2.ons.gov.uk/confluence/display/SDC/RH+-+Authentication+-+Unlinked+UAC
+   * https://collaborate2.ons.gov.uk/confluence/display/SDC/Business+Rules
    *
    * @throws CTPException - exception
    */
@@ -553,10 +554,7 @@ public class UniqueAccessCodeServiceImplTest {
   public void testLinkingMatrix() throws Exception {
     doLinkingTest(FormType.H, CaseType.HH, LinkingExpectation.OK);
     doLinkingTest(FormType.H, CaseType.SPG, LinkingExpectation.OK);
-    doLinkingTest(FormType.H, CaseType.CE, LinkingExpectation.OK);
-    doLinkingTest(FormType.H, CaseType.HH, LinkingExpectation.OK);
-    doLinkingTest(FormType.H, CaseType.SPG, LinkingExpectation.OK);
-    doLinkingTest(FormType.H, CaseType.CE, LinkingExpectation.OK);
+    doLinkingTest(FormType.H, CaseType.CE, LinkingExpectation.INVALID);
 
     doLinkingTest(FormType.I, CaseType.HH, LinkingExpectation.OK);
     doLinkingTest(FormType.I, CaseType.SPG, LinkingExpectation.OK);


### PR DESCRIPTION
# Motivation and Context
Simple change to stop the linking of a HH UAC to a CE case.

# What has changed
Removal of invalid combination from LinkingCombination enumeration of valid combinations.

# How to test?
Relevant unit test amended for now invalid combination. Duplicate testing of some combinations also removed. 
Has also been run against census-rh-cucumber to ensure has not caused any tests to fail.
Have also tested that UI displays the correct page on receipt of the HTTP Bad Request response for this now invalid combination.

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1332
