### PR TITLE
Cr 1459 rate limit eq launch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>census-int-rate-limiter-client</artifactId>
-      <version>0.0.9-SNAPSHOT</version>
+      <version>0.0.9</version>
     </dependency>
 
     <!-- ONS END -->

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>census-int-rate-limiter-client</artifactId>
-      <version>0.0.8</version>
+      <version>0.0.9-SNAPSHOT</version>
     </dependency>
 
     <!-- ONS END -->

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/AppConfig.java
@@ -23,4 +23,5 @@ public class AppConfig {
   private RateLimiterConfig rateLimiter;
   private NotifyConfig notify;
   private WebformConfig webform;
+  private LoadsheddingConfig loadshedding;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/AppConfig.java
@@ -4,10 +4,12 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.validation.annotation.Validated;
 import uk.gov.ons.ctp.common.config.CustomCircuitBreakerConfig;
 
 /** Application Config bean */
 @EnableRetry
+@Validated
 @Configuration
 @ConfigurationProperties
 @Data

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/LoadsheddingConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/LoadsheddingConfig.java
@@ -1,0 +1,8 @@
+package uk.gov.ons.ctp.integration.rhsvc.config;
+
+import lombok.Data;
+
+@Data
+public class LoadsheddingConfig {
+  private int modulus;
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/LoadsheddingConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/LoadsheddingConfig.java
@@ -1,8 +1,11 @@
 package uk.gov.ons.ctp.integration.rhsvc.config;
 
+import javax.validation.constraints.Min;
 import lombok.Data;
 
 @Data
 public class LoadsheddingConfig {
+
+  @Min(1)
   private int modulus;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/SurveyLaunchedDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/SurveyLaunchedDTO.java
@@ -17,4 +17,6 @@ public class SurveyLaunchedDTO implements Serializable {
   @NotNull private UUID caseId;
 
   @NotNull private String agentId;
+
+  private String clientIP;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -144,3 +144,6 @@ webform:
 notify:
   api-key: dummy-key
   base-url: https://api.notifications.service.gov.uk
+
+loadshedding:
+  modulus: 10

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/SurveyLaunchedEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/SurveyLaunchedEndpointUnitTest.java
@@ -52,51 +52,51 @@ public final class SurveyLaunchedEndpointUnitTest {
   @Test
   public void surveyLaunchedSuccessCaseEmptyString() throws Exception {
     Mockito.doNothing().when(surveyLaunchedService).surveyLaunched(any());
-    callEndointExpectingSuccess();
+    callEndpointExpectingSuccess();
   }
 
   @Test
   public void surveyLaunchedSuccessCaseAssistedDigitalLocation() throws Exception {
     Mockito.doNothing().when(surveyLaunchedService).surveyLaunched(any());
-    callEndointExpectingSuccess();
+    callEndpointExpectingSuccess();
   }
 
   @Test
   public void shouldRejectMissingQuestionnaireId() throws Exception {
     dto.setQuestionnaireId(null);
-    callEndointExpectingBadRequest();
+    callEndpointExpectingBadRequest();
   }
 
   @Test
   public void shouldLaunchWithMissingClientIP() throws Exception {
     dto.setClientIP(null);
-    callEndointExpectingSuccess();
+    callEndpointExpectingSuccess();
   }
 
   @Test
   public void shouldRejectInvalidCaseId() throws Exception {
     String surveyLaunchedRequestBody =
         "{ \"questionnaireId\": \"23434234234\",   \"caseId\": \"euieuieu@#$@#$\" }";
-    callEndointExpectingBadRequest(surveyLaunchedRequestBody);
+    callEndpointExpectingBadRequest(surveyLaunchedRequestBody);
   }
 
   @Test
   public void shouldRejectInvalidRequest() throws Exception {
     String surveyLaunchedRequestBody = "uoeuoeu 45345345 euieuiaooo";
-    callEndointExpectingBadRequest(surveyLaunchedRequestBody);
+    callEndpointExpectingBadRequest(surveyLaunchedRequestBody);
   }
 
-  private void callEndointExpectingSuccess() throws Exception {
+  private void callEndpointExpectingSuccess() throws Exception {
     mockMvc
         .perform(postJson("/surveyLaunched", mapper.writeValueAsString(dto)))
         .andExpect(status().isOk());
   }
 
-  private void callEndointExpectingBadRequest() throws Exception {
-    callEndointExpectingBadRequest(mapper.writeValueAsString(dto));
+  private void callEndpointExpectingBadRequest() throws Exception {
+    callEndpointExpectingBadRequest(mapper.writeValueAsString(dto));
   }
 
-  private void callEndointExpectingBadRequest(String body) throws Exception {
+  private void callEndpointExpectingBadRequest(String body) throws Exception {
     mockMvc.perform(postJson("/surveyLaunched", body)).andExpect(status().isBadRequest());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/SurveyLaunchedEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/SurveyLaunchedEndpointUnitTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.ons.ctp.common.MvcHelper.postJson;
 import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,8 +16,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.error.RestExceptionHandler;
 import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
+import uk.gov.ons.ctp.integration.rhsvc.representation.SurveyLaunchedDTO;
 import uk.gov.ons.ctp.integration.rhsvc.service.SurveyLaunchedService;
 
 /** Respondent Home Endpoint Unit tests */
@@ -26,7 +29,10 @@ public final class SurveyLaunchedEndpointUnitTest {
 
   @Mock SurveyLaunchedService surveyLaunchedService;
 
+  private ObjectMapper mapper = new ObjectMapper();
+
   private MockMvc mockMvc;
+  private SurveyLaunchedDTO dto;
 
   /**
    * Set up of tests
@@ -40,56 +46,57 @@ public final class SurveyLaunchedEndpointUnitTest {
             .setHandlerExceptionResolvers(mockAdviceFor(RestExceptionHandler.class))
             .setMessageConverters(new MappingJackson2HttpMessageConverter(new CustomObjectMapper()))
             .build();
+    dto = FixtureHelper.loadClassFixtures(SurveyLaunchedDTO[].class).get(0);
   }
 
   @Test
   public void surveyLaunchedSuccessCaseEmptyString() throws Exception {
     Mockito.doNothing().when(surveyLaunchedService).surveyLaunched(any());
-
-    String surveyLaunchedRequestBody =
-        "{ \"questionnaireId\": \"23434234234\", "
-            + "\"caseId\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\", "
-            + "\"agentId\": \"\"}";
-    mockMvc
-        .perform(postJson("/surveyLaunched", surveyLaunchedRequestBody))
-        .andExpect(status().isOk());
+    callEndointExpectingSuccess();
   }
 
   @Test
   public void surveyLaunchedSuccessCaseAssistedDigitalLocation() throws Exception {
     Mockito.doNothing().when(surveyLaunchedService).surveyLaunched(any());
+    callEndointExpectingSuccess();
+  }
 
+  @Test
+  public void shouldRejectMissingQuestionnaireId() throws Exception {
+    dto.setQuestionnaireId(null);
+    callEndointExpectingBadRequest();
+  }
+
+  @Test
+  public void shouldLaunchWithMissingClientIP() throws Exception {
+    dto.setClientIP(null);
+    callEndointExpectingSuccess();
+  }
+
+  @Test
+  public void shouldRejectInvalidCaseId() throws Exception {
     String surveyLaunchedRequestBody =
-        "{ \"questionnaireId\": \"23434234234\", "
-            + "\"caseId\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\", "
-            + "\"agentId\": \"1000007\"}";
+        "{ \"questionnaireId\": \"23434234234\",   \"caseId\": \"euieuieu@#$@#$\" }";
+    callEndointExpectingBadRequest(surveyLaunchedRequestBody);
+  }
+
+  @Test
+  public void shouldRejectInvalidRequest() throws Exception {
+    String surveyLaunchedRequestBody = "uoeuoeu 45345345 euieuiaooo";
+    callEndointExpectingBadRequest(surveyLaunchedRequestBody);
+  }
+
+  private void callEndointExpectingSuccess() throws Exception {
     mockMvc
-        .perform(postJson("/surveyLaunched", surveyLaunchedRequestBody))
+        .perform(postJson("/surveyLaunched", mapper.writeValueAsString(dto)))
         .andExpect(status().isOk());
   }
 
-  @Test
-  public void surveyLaunchedWithMissingQuestionnaireId() throws Exception {
-    String surveyLaunchedRequestBody = "{ \"caseId\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\" }";
-    mockMvc
-        .perform(postJson("/surveyLaunched", surveyLaunchedRequestBody))
-        .andExpect(status().isBadRequest());
+  private void callEndointExpectingBadRequest() throws Exception {
+    callEndointExpectingBadRequest(mapper.writeValueAsString(dto));
   }
 
-  @Test
-  public void surveyLaunchedWithInvalidCaseId() throws Exception {
-    String surveyLaunchedRequestBody =
-        "{ \"questionnaireId\": \"23434234234\",   \"caseId\": \"euieuieu@#$@#$\" }";
-    mockMvc
-        .perform(postJson("/surveyLaunched", surveyLaunchedRequestBody))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  public void surveyLaunchedWithInvalidRequest() throws Exception {
-    String surveyLaunchedRequestBody = "uoeuoeu 45345345 euieuiaooo";
-    mockMvc
-        .perform(postJson("/surveyLaunched", surveyLaunchedRequestBody))
-        .andExpect(status().isBadRequest());
+  private void callEndointExpectingBadRequest(String body) throws Exception {
+    mockMvc.perform(postJson("/surveyLaunched", body)).andExpect(status().isBadRequest());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/SurveyLaunchedServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/SurveyLaunchedServiceImplTest.java
@@ -2,47 +2,89 @@ package uk.gov.ons.ctp.integration.rhsvc.service.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.UUID;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ons.ctp.common.event.EventPublisher;
 import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
 import uk.gov.ons.ctp.common.event.EventPublisher.Source;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchedResponse;
+import uk.gov.ons.ctp.integration.ratelimiter.client.RateLimiterClient;
+import uk.gov.ons.ctp.integration.ratelimiter.client.RateLimiterClient.Domain;
+import uk.gov.ons.ctp.integration.rhsvc.config.AppConfig;
+import uk.gov.ons.ctp.integration.rhsvc.config.LoadsheddingConfig;
+import uk.gov.ons.ctp.integration.rhsvc.config.RateLimiterConfig;
 import uk.gov.ons.ctp.integration.rhsvc.representation.SurveyLaunchedDTO;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SurveyLaunchedServiceImplTest {
+  private static final int A_MODULUS = 10;
+  private static final String AN_IP_ADDR = "254.123.786.3";
 
-  @Mock EventPublisher publisher;
+  @Mock private EventPublisher publisher;
+  @Mock private RateLimiterClient rateLimiterClient;
+  @Mock private AppConfig appConfig;
 
   @InjectMocks SurveyLaunchedServiceImpl surveyLaunchedService;
 
   @Captor ArgumentCaptor<SurveyLaunchedResponse> sendEventCaptor;
 
-  @Test
-  public void testSurveyLaunchedAddressAgentIdValue() throws Exception {
-    // Give a survey launched request to the service layer
-    SurveyLaunchedDTO surveyLaunchedDTO = new SurveyLaunchedDTO();
+  private SurveyLaunchedDTO surveyLaunchedDTO;
+
+  @Before
+  public void setup() {
+    mockEnableRateLimiter(true);
+
+    LoadsheddingConfig loadsheddingConf = new LoadsheddingConfig();
+    loadsheddingConf.setModulus(10);
+    when(appConfig.getLoadshedding()).thenReturn(loadsheddingConf);
+
+    createPayload();
+  }
+
+  private void createPayload() {
+    surveyLaunchedDTO = new SurveyLaunchedDTO();
     surveyLaunchedDTO.setQuestionnaireId("1234");
     surveyLaunchedDTO.setCaseId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afa6"));
     surveyLaunchedDTO.setAgentId("1000007");
+    surveyLaunchedDTO.setClientIP(AN_IP_ADDR);
+  }
+
+  private void mockEnableRateLimiter(boolean enabled) {
+    RateLimiterConfig config = new RateLimiterConfig();
+    config.setEnabled(enabled);
+    when(appConfig.getRateLimiter()).thenReturn(config);
+  }
+
+  private void verifyRateLimiterCalled() throws Exception {
+    verify(rateLimiterClient).checkEqLaunchLimit(eq(Domain.RH), eq(AN_IP_ADDR), eq(A_MODULUS));
+  }
+
+  private void verifyRateLimiterNotCalled() throws Exception {
+    verify(rateLimiterClient, never())
+        .checkEqLaunchLimit(eq(Domain.RH), eq(AN_IP_ADDR), eq(A_MODULUS));
+  }
+
+  private void callAndVerifySurveyLaunched(Channel expectedChannel) throws Exception {
     surveyLaunchedService.surveyLaunched(surveyLaunchedDTO);
 
     // Get hold of the event pay load that surveyLaunchedService created
-    Mockito.verify(publisher)
+    verify(publisher)
         .sendEvent(
             eq(EventType.SURVEY_LAUNCHED),
             eq(Source.RESPONDENT_HOME),
-            eq(Channel.AD),
+            eq(expectedChannel),
             sendEventCaptor.capture());
     SurveyLaunchedResponse eventPayload = sendEventCaptor.getValue();
 
@@ -50,51 +92,32 @@ public class SurveyLaunchedServiceImplTest {
     assertEquals(surveyLaunchedDTO.getQuestionnaireId(), eventPayload.getQuestionnaireId());
     assertEquals(surveyLaunchedDTO.getCaseId(), eventPayload.getCaseId());
     assertEquals(surveyLaunchedDTO.getAgentId(), eventPayload.getAgentId());
+  }
+
+  @Test
+  public void testSurveyLaunchedAddressAgentIdValue() throws Exception {
+    callAndVerifySurveyLaunched(Channel.AD);
+    verifyRateLimiterCalled();
   }
 
   @Test
   public void testSurveyLaunchedAddressAgentIdEmptyString() throws Exception {
-    // Give a survey launched request to the service layer
-    SurveyLaunchedDTO surveyLaunchedDTO = new SurveyLaunchedDTO();
-    surveyLaunchedDTO.setQuestionnaireId("1234");
-    surveyLaunchedDTO.setCaseId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afa6"));
     surveyLaunchedDTO.setAgentId("");
-    surveyLaunchedService.surveyLaunched(surveyLaunchedDTO);
-
-    // Get hold of the event pay load that surveyLaunchedService created
-    Mockito.verify(publisher)
-        .sendEvent(
-            eq(EventType.SURVEY_LAUNCHED),
-            eq(Source.RESPONDENT_HOME),
-            eq(Channel.RH),
-            sendEventCaptor.capture());
-    SurveyLaunchedResponse eventPayload = sendEventCaptor.getValue();
-
-    // Verify contents of pay load object
-    assertEquals(surveyLaunchedDTO.getQuestionnaireId(), eventPayload.getQuestionnaireId());
-    assertEquals(surveyLaunchedDTO.getCaseId(), eventPayload.getCaseId());
-    assertEquals(surveyLaunchedDTO.getAgentId(), eventPayload.getAgentId());
+    callAndVerifySurveyLaunched(Channel.RH);
+    verifyRateLimiterCalled();
   }
 
   @Test
   public void testSurveyLaunchedAddressAgentIdNull() throws Exception {
-    // Give a survey launched request to the service layer
-    SurveyLaunchedDTO surveyLaunchedDTO = new SurveyLaunchedDTO();
-    surveyLaunchedDTO.setCaseId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afa6"));
-    surveyLaunchedService.surveyLaunched(surveyLaunchedDTO);
+    surveyLaunchedDTO.setAgentId(null);
+    callAndVerifySurveyLaunched(Channel.RH);
+    verifyRateLimiterCalled();
+  }
 
-    // Get hold of the event pay load that surveyLaunchedService created
-    Mockito.verify(publisher)
-        .sendEvent(
-            eq(EventType.SURVEY_LAUNCHED),
-            eq(Source.RESPONDENT_HOME),
-            eq(Channel.RH),
-            sendEventCaptor.capture());
-    SurveyLaunchedResponse eventPayload = sendEventCaptor.getValue();
-
-    // Verify contents of pay load object
-    assertEquals(surveyLaunchedDTO.getQuestionnaireId(), eventPayload.getQuestionnaireId());
-    assertEquals(surveyLaunchedDTO.getCaseId(), eventPayload.getCaseId());
-    assertEquals(surveyLaunchedDTO.getAgentId(), eventPayload.getAgentId());
+  @Test
+  public void shouldNotCallRateLimterWhenNotEnabled() throws Exception {
+    mockEnableRateLimiter(false);
+    callAndVerifySurveyLaunched(Channel.AD);
+    verifyRateLimiterNotCalled();
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/WebformServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/WebformServiceImplTest.java
@@ -70,9 +70,6 @@ public class WebformServiceImplTest extends WebformServiceImplTestBase {
 
   @Autowired WebformService webformService;
 
-  @MockBean(name = "envoyLimiterCb")
-  private CircuitBreaker envoyCircuitBreaker;
-
   @MockBean private RateLimiterClient rateLimiterClient;
 
   @Captor ArgumentCaptor<WebformDTO> webformEventCaptor;

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/endpoint/SurveyLaunchedEndpointUnitTest.SurveyLaunchedDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/endpoint/SurveyLaunchedEndpointUnitTest.SurveyLaunchedDTO.json
@@ -1,0 +1,6 @@
+{
+  "questionnaireId": "23434234234",
+  "caseId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "agentId": "1000007",
+  "clientIP": "172.16.254.1"
+}


### PR DESCRIPTION
# Motivation and Context
CR-1459 describes the requirement for Rate limiting our calls to EQ launcher via the RHSvc endpoint survey-launched call.

# What has changed
- now relies on updated rate-limiter-client , as in PR https://github.com/ONSdigital/census-int-rate-limiter-client/pull/9
- adds `clientIp` to survey launched DTO
- adds a "load shedding modulus" configuration (which must be > 0) to send to the rate limiting client when survery launched event is sent.
- unit tests updated as per usual

# How to test?

CR-1509 RHUI changes have already been merged, so RHUI is ready to fit with this change.

- configure RH DEV envoy rate limiter to manageable rates for the EQLAUNCH for all modulus values.
- deploy RHSvc to DEV, switch to envoy rate limiter , rather than mock.
- go to RHUI in DEV, use a valid UAC and try to launch EQ several times until you reach limit configured above.
- alternatively, run locally against mock rate limiter, and instruct it to return 429, and see your local RHUI webpage process the 429 and present error page.

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1459
