### PR TITLE
Cr 1540 encrypt phone number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>census-int-rate-limiter-client</artifactId>
-      <version>0.0.8</version>
+      <version>0.0.10-SNAPSHOT</version>
     </dependency>
 
     <!-- ONS END -->

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>census-int-rate-limiter-client</artifactId>
-      <version>0.0.10-SNAPSHOT</version>
+      <version>0.0.10</version>
     </dependency>
 
     <!-- ONS END -->

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcApplication.java
@@ -110,7 +110,8 @@ public class RHSvcApplication {
     var statusMapping = clientErrorMapping();
     RestClient restClient =
         new RestClient(clientConfig, statusMapping, HttpStatus.INTERNAL_SERVER_ERROR);
-    return new RateLimiterClient(restClient, circuitBreaker);
+    String password = appConfig.getLogging().getEncryption().getPassword();
+    return new RateLimiterClient(restClient, circuitBreaker, password);
   }
 
   private Map<HttpStatus, HttpStatus> clientErrorMapping() {

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/Logging.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/config/Logging.java
@@ -1,11 +1,16 @@
 package uk.gov.ons.ctp.integration.rhsvc.config;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 
-// import net.sourceforge.cobertura.CoverageIgnore;
-
-// @CoverageIgnore
 @Data
 public class Logging {
   private boolean useJson;
+  @NotNull private Encryption encryption;
+
+  @Data
+  public static class Encryption {
+    @NotBlank private String password;
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,8 @@ logging:
     org.springframework: INFO
   profile: DEV
   useJson: true
+  encryption:
+    password: CENSUS
 
 collectionExerciseId : 34d7f3bb-91c9-45d0-bb2d-90afce4fc790
 


### PR DESCRIPTION
# Motivation and Context
CR-1540 describes a need to encrypt the telephone number logged when rate limiting a fulfilment.
The rate-limiter code has now been changed, to RHSvc must be adapted to provide the password for encryption.

# What has changed
- password configured in the logging in application.yml
- rate limiter client constructed with password

# How to test?
- start RHSvc
- trigger the fulfilment endpoint, either via RHUI or curl or somesuch
- observe logging of rate limiter entry.

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1540