### PR TITLE
CR-1692 make sure EstabType has known code for published event

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/ServiceUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/ServiceUtil.java
@@ -68,7 +68,7 @@ public class ServiceUtil {
     address.setPostcode(request.getPostcode());
     address.setUprn(Long.toString(request.getUprn().getValue()));
     address.setAddressType(caseType.name());
-    address.setEstabType(request.getEstabType());
+    address.setEstabType(EstabType.forCode(request.getEstabType()).getCode());
     address.setAddressLevel(
         caseType.equals(CaseType.CE) ? AddressLevel.E.name() : AddressLevel.U.name());
     newCase.setAddress(address);

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplTest.java
@@ -325,28 +325,36 @@ public class CaseServiceImplTest {
 
   @Test
   public void createNewCase_CE() throws Exception {
-    doCreateNewCaseTest(EstabType.CARE_HOME, AddressType.CE, CaseType.CE, AddressLevel.E);
+    doCreateNewCaseTest(
+        EstabType.CARE_HOME.getCode(),
+        EstabType.CARE_HOME,
+        AddressType.CE,
+        CaseType.CE,
+        AddressLevel.E);
   }
 
   @Test
   public void createNewCase_HH() throws Exception {
-    doCreateNewCaseTest(EstabType.HOUSEHOLD, AddressType.HH, CaseType.HH, AddressLevel.U);
+    doCreateNewCaseTest(
+        "Household", EstabType.HOUSEHOLD, AddressType.HH, CaseType.HH, AddressLevel.U);
   }
 
   @Test
   public void createNewCase_withNoAddressTypeForEstab() throws Exception {
     // In this test the Address type will be used to set the case type
-    doCreateNewCaseTest(EstabType.OTHER, AddressType.SPG, CaseType.SPG, AddressLevel.U);
+    doCreateNewCaseTest(
+        "Floating palace", EstabType.OTHER, AddressType.SPG, CaseType.SPG, AddressLevel.U);
   }
 
   private void doCreateNewCaseTest(
-      EstabType estabType,
+      String estabType,
+      EstabType expectedEstabType,
       AddressType addressType,
       CaseType expectedCaseType,
       AddressLevel expectedAddressLevel)
       throws Exception {
     CaseRequestDTO request = FixtureHelper.loadClassFixtures(CaseRequestDTO[].class).get(0);
-    request.setEstabType(estabType.getCode());
+    request.setEstabType(estabType);
     request.setAddressType(addressType);
 
     // Invoke code under test
@@ -354,6 +362,7 @@ public class CaseServiceImplTest {
 
     Address expectedAddress = mapperFacade.map(request, Address.class);
     expectedAddress.setAddressLevel(expectedAddressLevel.name());
+    expectedAddress.setEstabType(expectedEstabType.getCode());
 
     // Verify returned case
     testUtil.validateCaseDTO(expectedCaseType, expectedAddress, newCase);

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.domain.AddressLevel;
 import uk.gov.ons.ctp.common.domain.CaseType;
+import uk.gov.ons.ctp.common.domain.EstabType;
 import uk.gov.ons.ctp.common.domain.FormType;
 import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -624,7 +625,7 @@ public class UniqueAccessCodeServiceImplTest {
     expectedAddress.setUprn(Long.toString(request.getUprn().getValue()));
     expectedAddress.setAddressType(caseType.name());
     expectedAddress.setAddressLevel(AddressLevel.U.name());
-    expectedAddress.setEstabType(request.getEstabType());
+    expectedAddress.setEstabType(EstabType.forCode(request.getEstabType()).getCode());
 
     return expectedAddress;
   }

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.CaseRequestDTO.CEAddress.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.CaseRequestDTO.CEAddress.json
@@ -6,6 +6,6 @@
   "region": "E",
   "postcode": "BY14 6AB",
   "uprn": "305634838282",
-  "estabType": "CARE_HOME",
+  "estabType": "care_home",
   "addressType": "CE"
 }

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.CaseRequestDTO.SPGAddress.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.CaseRequestDTO.SPGAddress.json
@@ -6,6 +6,6 @@
   "region": "E",
   "postcode": "BY14 6AB",
   "uprn": "305634838282",
-  "estabType": "MARINA",
+  "estabType": "Marina",
   "addressType": "SPG"
 }

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.CaseRequestDTO.householdAddress.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.CaseRequestDTO.householdAddress.json
@@ -6,6 +6,6 @@
   "region": "E",
   "postcode": "BY14 6AB",
   "uprn": "305634838282",
-  "estabType": "HOUSEHOLD",
+  "estabType": "Household",
   "addressType": "HH"
 }


### PR DESCRIPTION
# Motivation and Context
RM fails when receiving  NEW_ADDRESS_REPORTED when the estabType is not one of the proper upper case codes.
Before this PR we are mapping things straight from AIMS which sometimes has estabType as camel-case , eg "Household" instead of "HOUSEHOLD"

# What has changed
- Ensure estabType is mapped to proper code

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1692
