### PR TITLE
Cr 1749 dont return hi for create case

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/repository/RespondentDataRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/repository/RespondentDataRepository.java
@@ -16,8 +16,6 @@ public interface RespondentDataRepository {
 
   Optional<CollectionCase> readCollectionCase(String caseId) throws CTPException;
 
-  Optional<CollectionCase> readNonHILatestValidCollectionCaseByUprn(String uprn)
+  Optional<CollectionCase> readNonHILatestCollectionCaseByUprn(String uprn, boolean onlyValid)
       throws CTPException;
-
-  Optional<CollectionCase> readLatestCollectionCaseByUprn(String uprn) throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RespondentDataRepositoryImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RespondentDataRepositoryImpl.java
@@ -96,7 +96,7 @@ public class RespondentDataRepositoryImpl implements RespondentDataRepository {
    * whether the case is valid.
    *
    * @param uprn - is the uprn that the target case(s) must contain.
-   * @param onlyValid - true if only valid cases to be returned; false otherwise
+   * @param onlyValid - true if only valid cases to be returned; false if we don't care
    * @return - Optional containing 1 de-serialised version of the stored object. If no matching
    *     cases are found then an empty Optional is returned.
    * @throws CTPException - if a cloud exception was detected.
@@ -113,6 +113,7 @@ public class RespondentDataRepositoryImpl implements RespondentDataRepository {
    * Filter search results returning Latest !addressInvalid non HI case
    *
    * @param searchResults - Search results found in dataStore by searching by uprn
+   * @param onlyValid - true if only valid cases to be returned; false if we don't care
    * @return Optional of the resulting collection case or Empty
    */
   private Optional<CollectionCase> filterLatestValidNonHiCollectionCaseSearchResults(

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RespondentDataRepositoryImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RespondentDataRepositoryImpl.java
@@ -92,39 +92,21 @@ public class RespondentDataRepositoryImpl implements RespondentDataRepository {
   }
 
   /**
-   * Read case objects from cloud based on its uprn. Filter by non HI, not addressInvalid, latest
-   * case
+   * Read case objects from cloud based on its uprn. Filter by non HI, latest case, and optionally
+   * whether the case is valid.
    *
    * @param uprn - is the uprn that the target case(s) must contain.
+   * @param onlyValid - true if only valid cases to be returned; false otherwise
    * @return - Optional containing 1 de-serialised version of the stored object. If no matching
    *     cases are found then an empty Optional is returned.
    * @throws CTPException - if a cloud exception was detected.
    */
   @Override
-  public Optional<CollectionCase> readNonHILatestValidCollectionCaseByUprn(final String uprn)
-      throws CTPException {
+  public Optional<CollectionCase> readNonHILatestCollectionCaseByUprn(
+      final String uprn, boolean onlyValid) throws CTPException {
     List<CollectionCase> searchResults =
         cloudDataStore.search(CollectionCase.class, caseSchema, SEARCH_BY_UPRN_PATH, uprn);
-    return filterLatestValidNonHiCollectionCaseSearchResults(searchResults);
-  }
-
-  /**
-   * Read the latest case from cloud storage based on its uprn.
-   *
-   * @param uprn - is the uprn that the target case(s) must contain.
-   * @return - Optional containing the latest case or Empty.
-   * @throws CTPException - if a cloud exception was detected.
-   */
-  @Override
-  public Optional<CollectionCase> readLatestCollectionCaseByUprn(final String uprn)
-      throws CTPException {
-    List<CollectionCase> searchResults =
-        cloudDataStore.search(CollectionCase.class, caseSchema, SEARCH_BY_UPRN_PATH, uprn);
-
-    Optional<CollectionCase> latestCase =
-        searchResults.stream().max(Comparator.comparing(CollectionCase::getCreatedDateTime));
-
-    return latestCase;
+    return filterLatestValidNonHiCollectionCaseSearchResults(searchResults, onlyValid);
   }
 
   /**
@@ -134,10 +116,10 @@ public class RespondentDataRepositoryImpl implements RespondentDataRepository {
    * @return Optional of the resulting collection case or Empty
    */
   private Optional<CollectionCase> filterLatestValidNonHiCollectionCaseSearchResults(
-      final List<CollectionCase> searchResults) {
+      final List<CollectionCase> searchResults, boolean onlyValid) {
     return searchResults.stream()
         .filter(c -> !c.getCaseType().equals(CaseType.HI.name()))
-        .filter(c -> !c.isAddressInvalid())
+        .filter(c -> onlyValid ? !c.isAddressInvalid() : true)
         .max(Comparator.comparing(CollectionCase::getCreatedDateTime));
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImpl.java
@@ -64,7 +64,7 @@ public class CaseServiceImpl implements CaseService {
       throws CTPException {
 
     Optional<CollectionCase> caseFound =
-        dataRepo.readNonHILatestValidCollectionCaseByUprn(Long.toString(uprn.getValue()));
+        dataRepo.readNonHILatestCollectionCaseByUprn(Long.toString(uprn.getValue()), true);
     if (caseFound.isPresent()) {
       log.with("case", caseFound.get().getId())
           .with("uprn", uprn)
@@ -79,7 +79,7 @@ public class CaseServiceImpl implements CaseService {
   @Override
   public CaseDTO createNewCase(CaseRequestDTO request) throws CTPException {
 
-    Optional<CaseDTO> existingCase = getLatestCaseByUPRN(request.getUprn());
+    Optional<CaseDTO> existingCase = getLatestNonHICaseByUPRN(request.getUprn());
 
     CaseDTO caseToReturn;
     if (existingCase.isPresent()) {
@@ -366,12 +366,14 @@ public class CaseServiceImpl implements CaseService {
     }
   }
 
-  private Optional<CaseDTO> getLatestCaseByUPRN(UniquePropertyReferenceNumber uprn)
+  // get the latest Case , which can have a valid, or invalid address, but must not have a casetype
+  // of HI.
+  private Optional<CaseDTO> getLatestNonHICaseByUPRN(UniquePropertyReferenceNumber uprn)
       throws CTPException {
     Optional<CaseDTO> result = Optional.empty();
 
     Optional<CollectionCase> caseFound =
-        dataRepo.readLatestCollectionCaseByUprn(Long.toString(uprn.getValue()));
+        dataRepo.readNonHILatestCollectionCaseByUprn(Long.toString(uprn.getValue()), false);
     if (caseFound.isPresent()) {
       log.with("case", caseFound.get().getId())
           .with("uprn", uprn)

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImpl.java
@@ -126,8 +126,8 @@ public class UniqueAccessCodeServiceImpl implements UniqueAccessCodeService {
 
     // Read the Case(s) for the UPRN from firestore if we can
     Optional<CollectionCase> primaryCaseOptional =
-        dataRepo.readNonHILatestValidCollectionCaseByUprn(
-            Long.toString(request.getUprn().getValue()));
+        dataRepo.readNonHILatestCollectionCaseByUprn(
+            Long.toString(request.getUprn().getValue()), true);
     if (primaryCaseOptional.isPresent()) {
       primaryCase = primaryCaseOptional.get();
       log.with(primaryCase.getId()).debug("Found existing case");

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/WebformServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/WebformServiceImpl.java
@@ -44,7 +44,6 @@ public class WebformServiceImpl implements WebformService {
    *
    * @param notificationClient Gov.uk Notify service client
    * @param webformCircuitBreaker circuit breaker for calls to GOV.UK notify
-   * @param envoyCircuitBreaker circuit breaker for calls to envoy rate limiter
    * @param appConfig centralised configuration properties
    */
   @Autowired

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RespondentDataRepositoryImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/repository/impl/RespondentDataRepositoryImplTest.java
@@ -54,7 +54,7 @@ public class RespondentDataRepositoryImplTest {
     Assert.assertEquals(
         "Expects Empty Optional",
         Optional.empty(),
-        target.readNonHILatestValidCollectionCaseByUprn(UPRN_STRING));
+        target.readNonHILatestCollectionCaseByUprn(UPRN_STRING, true));
   }
 
   /** Returns Empty Optional where no valid caseType cases are returned from repository */
@@ -69,7 +69,7 @@ public class RespondentDataRepositoryImplTest {
     Assert.assertEquals(
         "Expects Empty Optional",
         Optional.empty(),
-        target.readNonHILatestValidCollectionCaseByUprn(UPRN_STRING));
+        target.readNonHILatestCollectionCaseByUprn(UPRN_STRING, true));
   }
 
   /** Returns Empty Optional where no valid Address cases are returned from repository */
@@ -84,7 +84,7 @@ public class RespondentDataRepositoryImplTest {
     Assert.assertEquals(
         "Expects Empty Optional",
         Optional.empty(),
-        target.readNonHILatestValidCollectionCaseByUprn(UPRN_STRING));
+        target.readNonHILatestCollectionCaseByUprn(UPRN_STRING, true));
   }
 
   /** Test retrieves latest case when all valid HH */
@@ -106,7 +106,7 @@ public class RespondentDataRepositoryImplTest {
     assertEquals(
         "Expects Item with Latest Date",
         Optional.of(collectionCase.get(1)),
-        target.readNonHILatestValidCollectionCaseByUprn(UPRN_STRING));
+        target.readNonHILatestCollectionCaseByUprn(UPRN_STRING, true));
   }
 
   /** Test retrieves latest valid case when actual latest date is an HI case */
@@ -129,7 +129,7 @@ public class RespondentDataRepositoryImplTest {
     assertEquals(
         "Expects HH Item With Latest Date",
         Optional.of(collectionCase.get(0)),
-        target.readNonHILatestValidCollectionCaseByUprn(UPRN_STRING));
+        target.readNonHILatestCollectionCaseByUprn(UPRN_STRING, true));
   }
 
   /** Test retrieves latest Address valid case when actual latest date is an HI case */
@@ -153,39 +153,30 @@ public class RespondentDataRepositoryImplTest {
     assertEquals(
         "Expects Latest Item With Valid Address",
         Optional.of(collectionCase.get(2)),
-        target.readNonHILatestValidCollectionCaseByUprn(UPRN_STRING));
+        target.readNonHILatestCollectionCaseByUprn(UPRN_STRING, true));
   }
 
-  /** Returns Empty Optional where no cases are returned from repository */
+  /** Test retrieves latest invalid Address case when actual latest date is an HI case */
   @Test
-  public void readLatestCollectionCaseByUprn_noCasesFound() throws Exception {
-
-    final List<CollectionCase> emptyList = new ArrayList<>();
-    when(mockCloudDataStore.search(
-            CollectionCase.class, target.caseSchema, searchByUprnPath, UPRN_STRING))
-        .thenReturn(emptyList);
-
-    Assert.assertEquals(
-        "Expects Empty Optional",
-        Optional.empty(),
-        target.readLatestCollectionCaseByUprn(UPRN_STRING));
-  }
-
-  /** Test which gets multiple cases from repo and returns the latest one. */
-  @Test
-  public void readLatestCollectionCaseByUprn_multipleCasesFound() throws Exception {
+  public void getLatestAddressCaseNoneHIByUPRNOnly() throws Exception {
 
     final Date earliest = new Date();
     final Date mid = DateUtils.addDays(new Date(), 1);
     final Date latest = DateUtils.addDays(new Date(), 2);
     collectionCase.get(0).setCreatedDateTime(mid);
+    collectionCase.get(0).setCaseType("HH");
+    collectionCase.get(0).setAddressInvalid(Boolean.TRUE); // INVALID , but EXPECTED
     collectionCase.get(1).setCreatedDateTime(latest);
+    collectionCase.get(1).setCaseType("HI"); // INVALID
     collectionCase.get(2).setCreatedDateTime(earliest);
+    collectionCase.get(2).setCaseType("HH"); // VALID
     when(mockCloudDataStore.search(
             CollectionCase.class, target.caseSchema, searchByUprnPath, UPRN_STRING))
         .thenReturn(collectionCase);
 
     assertEquals(
-        Optional.of(collectionCase.get(1)), target.readLatestCollectionCaseByUprn(UPRN_STRING));
+        "Expects Latest Item With non HI Address",
+        Optional.of(collectionCase.get(0)),
+        target.readNonHILatestCollectionCaseByUprn(UPRN_STRING, false));
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/CaseServiceImplTest.java
@@ -91,7 +91,7 @@ public class CaseServiceImplTest {
   @Test
   public void getCaseByUPRNFound() throws Exception {
 
-    when(dataRepo.readNonHILatestValidCollectionCaseByUprn(Long.toString(UPRN.getValue())))
+    when(dataRepo.readNonHILatestCollectionCaseByUprn(Long.toString(UPRN.getValue()), true))
         .thenReturn(Optional.of(collectionCase.get(0)));
 
     CollectionCase nonHICase = this.collectionCase.get(0);
@@ -116,7 +116,7 @@ public class CaseServiceImplTest {
   /** Test throws a CTPException where no valid Address cases are returned from repository */
   @Test(expected = CTPException.class)
   public void getInvalidAddressCaseByUPRNOnly() throws Exception {
-    when(dataRepo.readNonHILatestValidCollectionCaseByUprn(Long.toString(UPRN.getValue())))
+    when(dataRepo.readNonHILatestCollectionCaseByUprn(Long.toString(UPRN.getValue()), true))
         .thenThrow(new CTPException(null));
     caseSvc.getLatestValidNonHICaseByUPRN(UPRN);
   }
@@ -134,7 +134,7 @@ public class CaseServiceImplTest {
     collectionCase.get(0).setCreatedDateTime(mid);
     collectionCase.get(1).setCreatedDateTime(latest); // EXPECTED
     collectionCase.get(2).setCreatedDateTime(earliest);
-    when(dataRepo.readNonHILatestValidCollectionCaseByUprn(Long.toString(UPRN.getValue())))
+    when(dataRepo.readNonHILatestCollectionCaseByUprn(Long.toString(UPRN.getValue()), true))
         .thenReturn(Optional.of(collectionCase.get(1)));
     CaseDTO result = caseSvc.getLatestValidNonHICaseByUPRN(UPRN);
 
@@ -157,7 +157,7 @@ public class CaseServiceImplTest {
     collectionCase.get(1).setCaseType("HI"); // INVALID
     collectionCase.get(2).setCreatedDateTime(earliest);
     collectionCase.get(2).setCaseType("HH"); // VALID
-    when(dataRepo.readNonHILatestValidCollectionCaseByUprn(Long.toString(UPRN.getValue())))
+    when(dataRepo.readNonHILatestCollectionCaseByUprn(Long.toString(UPRN.getValue()), true))
         .thenReturn(Optional.of(collectionCase.get(0)));
     CaseDTO result = caseSvc.getLatestValidNonHICaseByUPRN(UPRN);
 
@@ -181,7 +181,7 @@ public class CaseServiceImplTest {
     collectionCase.get(1).setCaseType("HI"); // INVALID
     collectionCase.get(2).setCreatedDateTime(earliest);
     collectionCase.get(2).setCaseType("HH"); // VALID / EXPECTED
-    when(dataRepo.readNonHILatestValidCollectionCaseByUprn(Long.toString(UPRN.getValue())))
+    when(dataRepo.readNonHILatestCollectionCaseByUprn(Long.toString(UPRN.getValue()), true))
         .thenReturn(Optional.of(collectionCase.get(2)));
     CaseDTO result = caseSvc.getLatestValidNonHICaseByUPRN(UPRN);
 
@@ -195,7 +195,7 @@ public class CaseServiceImplTest {
   @Test(expected = CTPException.class)
   public void getCaseByUPRNNotFound() throws Exception {
 
-    when(dataRepo.readNonHILatestValidCollectionCaseByUprn(Long.toString(UPRN.getValue())))
+    when(dataRepo.readNonHILatestCollectionCaseByUprn(Long.toString(UPRN.getValue()), true))
         .thenReturn(Optional.empty());
 
     caseSvc.getLatestValidNonHICaseByUPRN(UPRN);
@@ -310,7 +310,8 @@ public class CaseServiceImplTest {
     CollectionCase existingCase = FixtureHelper.loadClassFixtures(CollectionCase[].class).get(0);
     existingCase.getAddress().setUprn(uprn);
     Optional<CollectionCase> existingCaseResult = Optional.of(existingCase);
-    when(dataRepo.readLatestCollectionCaseByUprn(eq(uprn))).thenReturn(existingCaseResult);
+    when(dataRepo.readNonHILatestCollectionCaseByUprn(eq(uprn), eq(false)))
+        .thenReturn(existingCaseResult);
 
     // Invoke code under test
     CaseDTO newCase = caseSvc.createNewCase(request);

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
@@ -605,7 +605,7 @@ public class UniqueAccessCodeServiceImplTest {
   private void mockDataRepoForReadNonHILatestValidCollectionCaseByUprn(
       UniquePropertyReferenceNumber uprn, CollectionCase fakeCase) throws CTPException {
     List<CollectionCase> cases = Stream.of(fakeCase).collect(Collectors.toList());
-    when(dataRepo.readNonHILatestValidCollectionCaseByUprn(eq(Long.toString(uprn.getValue()))))
+    when(dataRepo.readNonHILatestCollectionCaseByUprn(eq(Long.toString(uprn.getValue())), eq(true)))
         .thenReturn(Optional.of(cases.get(0)));
   }
 


### PR DESCRIPTION
# Motivation and Context
Fixes a bug where HI cases are returned when create case is called from RHUI.

This is a priority Production bug.
  
# What has changed
create case will search in firestore for the latest by UPRN, but will not return HI cases.

https://collaborate2.ons.gov.uk/jira/browse/CR-1749