### PR TITLE
Cr 1818 add estab type to case dto

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcBeanMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcBeanMapper.java
@@ -1,9 +1,13 @@
 package uk.gov.ons.ctp.integration.rhsvc;
 
 import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.converter.BidirectionalConverter;
 import ma.glasnost.orika.converter.ConverterFactory;
 import ma.glasnost.orika.impl.ConfigurableMapper;
+import ma.glasnost.orika.metadata.Type;
 import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.common.domain.EstabType;
 import uk.gov.ons.ctp.common.event.model.Address;
 import uk.gov.ons.ctp.common.event.model.AddressCompact;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
@@ -27,13 +31,16 @@ public class RHSvcBeanMapper extends ConfigurableMapper {
     ConverterFactory converterFactory = factory.getConverterFactory();
     converterFactory.registerConverter(new StringToUUIDConverter());
     converterFactory.registerConverter(new StringToUPRNConverter());
+    converterFactory.registerConverter(new EstabTypeConverter());
 
     factory
         .classMap(CollectionCase.class, CaseDTO.class)
+        .mapNulls(false)
         .field("id", "caseId")
         .field("address.addressType", "addressType")
         .field("address.region", "region")
         .field("address.addressLevel", "addressLevel")
+        .field("address.estabType", "estabType")
         .byDefault()
         .register();
 
@@ -47,5 +54,19 @@ public class RHSvcBeanMapper extends ConfigurableMapper {
 
     factory.classMap(AddressDTO.class, AddressCompact.class).byDefault().register();
     factory.classMap(Address.class, AddressCompact.class).byDefault().register();
+  }
+
+  static class EstabTypeConverter extends BidirectionalConverter<String, EstabType> {
+    @Override
+    public String convertFrom(
+        EstabType source, Type<String> destinationType, MappingContext mappingContext) {
+      return source.name();
+    }
+
+    @Override
+    public EstabType convertTo(
+        String source, Type<EstabType> destinationType, MappingContext mappingContext) {
+      return EstabType.forCode(source);
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcBeanMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcBeanMapper.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.integration.rhsvc;
 
+import ma.glasnost.orika.CustomMapper;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.converter.BidirectionalConverter;
@@ -7,6 +8,7 @@ import ma.glasnost.orika.converter.ConverterFactory;
 import ma.glasnost.orika.impl.ConfigurableMapper;
 import ma.glasnost.orika.metadata.Type;
 import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.common.domain.CaseType;
 import uk.gov.ons.ctp.common.domain.EstabType;
 import uk.gov.ons.ctp.common.event.model.Address;
 import uk.gov.ons.ctp.common.event.model.AddressCompact;
@@ -35,13 +37,25 @@ public class RHSvcBeanMapper extends ConfigurableMapper {
 
     factory
         .classMap(CollectionCase.class, CaseDTO.class)
-        .mapNulls(false)
         .field("id", "caseId")
         .field("address.addressType", "addressType")
         .field("address.region", "region")
         .field("address.addressLevel", "addressLevel")
         .field("address.estabType", "estabType")
         .byDefault()
+        .customize(
+            new CustomMapper<CollectionCase, CaseDTO>() {
+              @Override
+              public void mapAtoB(
+                  CollectionCase collectionCase, CaseDTO dto, MappingContext context) {
+                if (dto.getEstabType() == null) {
+                  dto.setEstabType(
+                      CaseType.HH.name().equals(dto.getCaseType())
+                          ? EstabType.HOUSEHOLD
+                          : EstabType.OTHER);
+                }
+              }
+            })
         .register();
 
     factory

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/CaseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/CaseDTO.java
@@ -27,5 +27,5 @@ public class CaseDTO {
 
   private String addressLevel;
 
-  @NotNull private EstabType estabType = EstabType.OTHER;
+  @NotNull private EstabType estabType;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/CaseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/representation/CaseDTO.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.godaddy.logging.LoggingScope;
 import com.godaddy.logging.Scope;
 import java.util.UUID;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
+import uk.gov.ons.ctp.common.domain.EstabType;
 
 /** Representation of a Case */
 @Data
@@ -24,4 +26,6 @@ public class CaseDTO {
   private String region;
 
   private String addressLevel;
+
+  @NotNull private EstabType estabType = EstabType.OTHER;
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcBeanMapperTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcBeanMapperTest.java
@@ -1,0 +1,67 @@
+package uk.gov.ons.ctp.integration.rhsvc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.UUID;
+import ma.glasnost.orika.MapperFacade;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.ons.ctp.common.FixtureHelper;
+import uk.gov.ons.ctp.common.domain.AddressType;
+import uk.gov.ons.ctp.common.domain.CaseType;
+import uk.gov.ons.ctp.common.domain.EstabType;
+import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
+import uk.gov.ons.ctp.common.event.model.CollectionCase;
+import uk.gov.ons.ctp.integration.rhsvc.representation.AddressDTO;
+import uk.gov.ons.ctp.integration.rhsvc.representation.CaseDTO;
+
+public class RHSvcBeanMapperTest {
+
+  private MapperFacade mapper = new RHSvcBeanMapper();
+
+  private CollectionCase collectionCase;
+
+  @Before
+  public void setup() {
+    collectionCase = FixtureHelper.loadClassFixtures(CollectionCase[].class).get(0);
+  }
+
+  private AddressDTO expectedAddress() {
+    AddressDTO addr = new AddressDTO();
+    addr.setAddressLine1("1 main street");
+    addr.setAddressLine2("upper upperingham");
+    addr.setAddressLine3("");
+    addr.setTownName("upton");
+    addr.setPostcode("UP103UP");
+    addr.setUprn(UniquePropertyReferenceNumber.create("123456"));
+    return addr;
+  }
+
+  @Test
+  public void shouldMapCollectionCaseToCaseDTO() {
+    CaseDTO dto = mapper.map(collectionCase, CaseDTO.class);
+    assertEquals(UUID.fromString("aa4477d1-dd3f-4c69-b181-7ff725dc9fa4"), dto.getCaseId());
+    assertEquals("10000000010", dto.getCaseRef());
+    assertEquals(CaseType.CE.name(), dto.getCaseType());
+    assertEquals(AddressType.CE.name(), dto.getAddressType());
+    assertEquals(expectedAddress(), dto.getAddress());
+    assertEquals("E", dto.getRegion());
+    assertEquals("E", dto.getAddressLevel());
+    assertEquals(EstabType.HOUSEHOLD, dto.getEstabType());
+  }
+
+  @Test
+  public void shouldMapCollectionCaseWithCamelCaseEstabTypeToCaseDTO() {
+    collectionCase.getAddress().setEstabType("Prison");
+    CaseDTO dto = mapper.map(collectionCase, CaseDTO.class);
+    assertEquals(EstabType.PRISON, dto.getEstabType());
+  }
+
+  // some Cases from RH have had null EstabType in production. Make sure we handle them.
+  @Test
+  public void shouldMapCollectionCaseWithNullEstabTypeToCaseDTO() {
+    collectionCase.getAddress().setEstabType(null);
+    CaseDTO dto = mapper.map(collectionCase, CaseDTO.class);
+    assertEquals(EstabType.OTHER, dto.getEstabType());
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcBeanMapperTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcBeanMapperTest.java
@@ -64,4 +64,13 @@ public class RHSvcBeanMapperTest {
     CaseDTO dto = mapper.map(collectionCase, CaseDTO.class);
     assertEquals(EstabType.OTHER, dto.getEstabType());
   }
+
+  // Household caseType should default to Household estabType if incoming estabType is null
+  @Test
+  public void shouldMapHouseholdCollectionCaseWithNullEstabTypeToCaseDTO() {
+    collectionCase.getAddress().setEstabType(null);
+    collectionCase.setCaseType(CaseType.HH.name());
+    CaseDTO dto = mapper.map(collectionCase, CaseDTO.class);
+    assertEquals(EstabType.HOUSEHOLD, dto.getEstabType());
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcBeanMapperTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/RHSvcBeanMapperTest.java
@@ -57,6 +57,13 @@ public class RHSvcBeanMapperTest {
     assertEquals(EstabType.PRISON, dto.getEstabType());
   }
 
+  @Test
+  public void shouldMapCollectionCaseWithUnrecognisedEstabTypeToCaseDTO() {
+    collectionCase.getAddress().setEstabType("XXX");
+    CaseDTO dto = mapper.map(collectionCase, CaseDTO.class);
+    assertEquals(EstabType.OTHER, dto.getEstabType());
+  }
+
   // some Cases from RH have had null EstabType in production. Make sure we handle them.
   @Test
   public void shouldMapCollectionCaseWithNullEstabTypeToCaseDTO() {

--- a/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/RHSvcBeanMapperTest.CollectionCase.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/rhsvc/RHSvcBeanMapperTest.CollectionCase.json
@@ -1,0 +1,33 @@
+[
+  {
+	"id": "aa4477d1-dd3f-4c69-b181-7ff725dc9fa4",
+	"caseRef": "10000000010",
+	"caseType": "CE",
+	"survey": "CENSUS",
+	"collectionExerciseId": "a66de4dc-3c3b-11e9-b210-d663bd873d93",
+	"address": {
+		"addressLine1": "1 main street",
+		"addressLine2": "upper upperingham",
+		"addressLine3": "",
+		"townName": "upton",
+		"postcode": "UP103UP",
+		"region": "E",
+		"latitude": "50.863849",
+		"longitude": "-1.229710",
+		"uprn": "123456",
+		"addressType": "CE",
+		"estabType": "HOUSEHOLD",
+		"addressLevel" : "E"
+	},
+	"contact": {
+		"title": "Ms",
+		"forename": "jo",
+		"surname": "smith",
+		"telNo": "+447890000000"
+	},
+	"actionableFrom": "2011-08-12T20:17:46.384Z",
+	"addressInvalid": false,
+	"handDelivery" : true,
+	"createdDateTime": "2020-06-01T20:17:46.384Z"
+  }
+]


### PR DESCRIPTION
# Motivation and Context
CR-1818 requires UI changes to handle NA addressType - this requires using RH case data for address checking and thus we need EstabType added to CaseDTO to provide the RHUI with required information.

# What has changed
- CaseDTO now carries EstabType
- mapper converts EstabType from that found in firestore
- similar logic to that from CR-1827 for CCSvc when when we don't know estabType, we can infer something from CaseType.

https://collaborate2.ons.gov.uk/jira/browse/CR-1818

See also https://collaborate2.ons.gov.uk/jira/browse/CR-1827
