### PR TITLE
CR-1853 Notify dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,21 +29,6 @@
     <tag>rhsvc-0.1.2</tag>
   </scm>
 
-  <profiles>
-    <profile>
-      <id>bintray</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>notify-repo</id>
-          <url>https://dl.bintray.com/gov-uk-notify/maven</url>
-        </repository>
-      </repositories>
-    </profile>
-  </profiles>
-
   <dependencies>
     <!-- Spring dependencies -->
 


### PR DESCRIPTION
# Motivation and Context
Gov Notify dependency now available from Maven central.

# What has changed
The GOV.UK Notify java client is now available from Maven central. There is no longer a need to set up the separate BinTray repository. The groupId and artifactId are unchanged and as the service has now a very short life expectancy there seems no reason to take any associated risk in moving to a later client version. I have therefore left the present version, which is available in Maven central.
Note, we are not changing the notification client code, just the repository from where it will be fetched.

# How to test?
Run the build. If you have run it previously the client version will be available in your local repository anyway. If not, or you remove your local version, if you have your Maven settings correct it should fetch the client from our JFrog repository. If JFrog no longer has it cached JFrog will fetch it from Maven central and deliver to you. If your Maven settings still point to the default Maven central then it will fetch it directly. 

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1853
